### PR TITLE
Improve LinkNYC layer display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vscode/launch.json

--- a/public/img/map/kiosk-5g.svg
+++ b/public/img/map/kiosk-5g.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+	<circle
+	    fill="#fcba03"
+	  	stroke="white"
+	  	r="3"
+	    stroke-width="2"
+	  	cx="5"
+	  	cy="5"
+	/>
+</svg>

--- a/src/components/Filters/component.js
+++ b/src/components/Filters/component.js
@@ -14,7 +14,8 @@ const labels = [
 	"potential",
 	"potential-hub",
 	"potential-supernode",
-	"linkNYC",
+	"linkNYC Classic",
+	"linkNYC 5G",
 	"sector"
 ];
 
@@ -23,7 +24,6 @@ export default class Filters extends PureComponent {
 		const { toggleFilter } = this.props;
 		const params = new URLSearchParams(this.props.location.search);
 		if (params.get("potential") === "true") toggleFilter("potential");
-		if (params.get("linknyc") === "true") toggleFilter("linkNYC");
 	}
 
 	render() {

--- a/src/components/MapView/KioskMarker.js
+++ b/src/components/MapView/KioskMarker.js
@@ -1,14 +1,46 @@
 import React, { PureComponent } from "react";
-import { Marker } from "react-google-maps";
+import { Marker, InfoWindow } from "react-google-maps";
 
 export default class KioskMarker extends PureComponent {
+
+	constructor(props) {
+		super(props);
+		
+		this.state = {
+		showInfo: false,
+		};
+	}
+
+	handleClick = () => {
+		this.setState(() => ({
+			showInfo: true,
+		}));
+	};
+
+	closeClick = () => {
+		this.setState(() => ({
+			showInfo: false,
+		}));
+	};
+
 	render() {
-		const { kiosk } = this.props;
+		const { kiosk, isClassic } = this.props;
 		const [lng, lat] = kiosk.coordinates;
+
 		const icon = {
-			url: "/img/map/kiosk.svg",
+			url: isClassic ? "/img/map/kiosk.svg": "/img/map/kiosk-5g.svg",
 			anchor: { x: 5, y: 5 }
 		};
-		return <Marker defaultPosition={{ lat, lng }} icon={icon} zIndex={1} />;
+		return <Marker defaultPosition={{ lat, lng }} icon={icon} zIndex={1} onClick={this.handleClick}>
+          {this.state.showInfo && (
+            <InfoWindow onCloseClick={this.handleClick}>
+              <div>
+			  	<span><b>ID:</b> {kiosk.id}</span><br/>
+			  	<span><b>Address:</b> {kiosk.street_address}</span><br/>
+			  	<span><b>Type:</b> {kiosk.type}</span><br/>
+				<span><b>Status:</b> {kiosk.status}</span></div>
+            </InfoWindow>
+          )}
+		</Marker>;
 	}
 }

--- a/src/components/MapView/component.js
+++ b/src/components/MapView/component.js
@@ -170,11 +170,11 @@ class MapView extends Component {
 				loadingElement={<div className="h-100 flex flex-column" />}
 				containerElement={<div className="h-100 flex flex-column" />}
 				mapElement={<div className="h-100 flex flex-column" />}
-				// googleMapURL="https://maps.googleapis.com/maps/api/js?key=AIzaSyBkBIy80YVhu7nYjVweruALNkpgFKquIEw"
-				googleMapURL="https://maps.googleapis.com/maps/api/js?key=AIzaSyA5HWodOyFI3NQJpnFUS-C2ZuDH5xBCGI4"
+				googleMapURL="https://maps.googleapis.com/maps/api/js?key=AIzaSyBkBIy80YVhu7nYjVweruALNkpgFKquIEw"
 			>
 				{this.renderLinks()}
 				{this.renderKiosks()}
+				{this.renderKiosks5g()}
 				{this.renderNodes()}
 				{this.renderNodeDetail()}
 				<Route
@@ -255,11 +255,18 @@ class MapView extends Component {
 	}
 
 	renderKiosks() {
-		const { kiosks } = this.props;
-		return kiosks.map(kiosk => (
-			<KioskMarker key={kiosk.id} kiosk={kiosk} />
+		const { kiosksClassic } = this.props;
+		return kiosksClassic.map(kiosk => (
+			<KioskMarker key={kiosk.id} kiosk={kiosk} isClassic={true} />
 		));
 	}
+
+	renderKiosks5g() {
+		const { kiosks5g } = this.props;
+		return kiosks5g.map(kiosk => (
+			<KioskMarker key={kiosk.id} kiosk={kiosk} isClassic={false} />
+		));
+	}	
 
 	renderNodeDetail() {
 		const { match } = this.props;

--- a/src/components/MapView/connected.js
+++ b/src/components/MapView/connected.js
@@ -5,7 +5,8 @@ const mapStateToProps = (state, ownProps) => ({
 	nodes: state.nodes,
 	links: state.links,
 	sectors: state.sectors,
-	kiosks: state.kiosks,
+	kiosksClassic: state.kiosksClassic,
+	kiosks5g: state.kiosks5g,
 	filters: state.filters
 });
 

--- a/src/components/NodeName.js
+++ b/src/components/NodeName.js
@@ -130,7 +130,7 @@ export const icons = {
 			</g>
 		</svg>
 	),
-	linkNYC: (
+	"linkNYC Classic": (
 		<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
 			<circle
 				cx="10"
@@ -139,6 +139,19 @@ export const icons = {
 				stroke="white"
 				strokeWidth="0"
 				fill="#01a2eb"
+				opacity="1"
+			/>
+		</svg>
+	),
+	"linkNYC 5G": (
+		<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20">
+			<circle
+				cx="10"
+				cy="10"
+				r="3"
+				stroke="white"
+				strokeWidth="0"
+				fill="#fcba03"
 				opacity="1"
 			/>
 		</svg>

--- a/src/data/kiosks.json
+++ b/src/data/kiosks.json
@@ -1,14590 +1,8 @@
 [
   {
-    "id": "LINK-000001",
-    "coordinates": [
-      -73.94209,
-      40.70099
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000002",
-    "coordinates": [
-      -73.94248859,
-      40.70166753
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000003",
-    "coordinates": [
-      -73.94216928,
-      40.70154219
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000004",
-    "coordinates": [
-      -73.94223924,
-      40.70193034
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000005",
-    "coordinates": [
-      -73.94291758,
-      40.70506042
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000008",
-    "coordinates": [
-      -73.93844701,
-      40.69887623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000010",
-    "coordinates": [
-      -73.93893235,
-      40.69895576
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000019",
-    "coordinates": [
-      -73.95592439,
-      40.64066623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000022",
-    "coordinates": [
-      -73.95360324,
-      40.63855961
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000025",
-    "coordinates": [
-      -73.94678067,
-      40.63213478
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000027",
-    "coordinates": [
-      -73.953439,
-      40.728133
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000029",
-    "coordinates": [
-      -73.95786908,
-      40.71777024
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000031",
-    "coordinates": [
-      -73.98193577,
-      40.67455551
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000032",
-    "coordinates": [
-      -73.97973799,
-      40.67761961
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000034",
-    "coordinates": [
-      -73.97406,
-      40.679568
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000035",
-    "coordinates": [
-      -73.97437146,
-      40.67963858
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000036",
-    "coordinates": [
-      -73.97325278,
-      40.67845279
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000039",
-    "coordinates": [
-      -73.990353,
-      40.664176
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000040",
-    "coordinates": [
-      -73.98695629,
-      40.66853323
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000041",
-    "coordinates": [
-      -73.986317,
-      40.669018
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000042",
-    "coordinates": [
-      -73.98595804,
-      40.66973105
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000043",
-    "coordinates": [
-      -73.982789,
-      40.673534
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000044",
-    "coordinates": [
-      -73.977006,
-      40.683625
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000045",
-    "coordinates": [
-      -73.980613,
-      40.688851
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000046",
-    "coordinates": [
-      -73.98086659,
-      40.68521833
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000047",
-    "coordinates": [
-      -73.98496961,
-      40.68681157
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000049",
-    "coordinates": [
-      -73.99314691,
-      40.6879008
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000051",
-    "coordinates": [
-      -73.9945262,
-      40.68538976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000052",
-    "coordinates": [
-      -73.99575348,
-      40.68248292
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000054",
-    "coordinates": [
-      -73.99002262,
-      40.6874966
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000056",
-    "coordinates": [
-      -73.98042355,
-      40.68764898
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000064",
-    "coordinates": [
-      -73.90457508,
-      40.86311405
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000067",
-    "coordinates": [
-      -73.89305944,
-      40.86021467
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000070",
-    "coordinates": [
-      -73.90324404,
-      40.86264365
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000072",
-    "coordinates": [
-      -73.898023,
-      40.861349
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000074",
-    "coordinates": [
-      -73.89858091,
-      40.86165512
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000076",
-    "coordinates": [
-      -73.89855259,
-      40.85915372
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000077",
-    "coordinates": [
-      -73.90454701,
-      40.86285548
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000087",
-    "coordinates": [
-      -73.89952057,
-      40.86208577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000090",
-    "coordinates": [
-      -73.89182996,
-      40.86199332
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000092",
-    "coordinates": [
-      -73.98336787,
-      40.76582962
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000108",
-    "coordinates": [
-      -73.98185929,
-      40.76700781
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000111",
-    "coordinates": [
-      -73.98198781,
-      40.76617479
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000114",
-    "coordinates": [
-      -73.98920582,
-      40.74320284
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000116",
-    "coordinates": [
-      -73.98901592,
-      40.74424305
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000120",
-    "coordinates": [
-      -73.98867089,
-      40.74512705
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000130",
-    "coordinates": [
-      -73.988399,
-      40.746624
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000134",
-    "coordinates": [
-      -73.9881009,
-      40.74813894
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000141",
-    "coordinates": [
-      -73.98808378,
-      40.74972091
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000146",
-    "coordinates": [
-      -73.98757374,
-      40.75233922
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000151",
-    "coordinates": [
-      -73.98738603,
-      40.75305908
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000155",
-    "coordinates": [
-      -73.98693515,
-      40.75449299
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000158",
-    "coordinates": [
-      -73.98635944,
-      40.75485087
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000162",
-    "coordinates": [
-      -73.9845408,
-      40.76041294
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000163",
-    "coordinates": [
-      -73.9848567,
-      40.76026604
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000164",
-    "coordinates": [
-      -73.98446631,
-      40.76064069
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000165",
-    "coordinates": [
-      -73.98428289,
-      40.76063217
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000166",
-    "coordinates": [
-      -73.98463363,
-      40.7607176
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000168",
-    "coordinates": [
-      -73.98427739,
-      40.76088277
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000173",
-    "coordinates": [
-      -73.9830769,
-      40.7625933
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000177",
-    "coordinates": [
-      -73.98262883,
-      40.76397808
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000178",
-    "coordinates": [
-      -73.98230856,
-      40.76412672
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000180",
-    "coordinates": [
-      -73.98236264,
-      40.76467196
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000182",
-    "coordinates": [
-      -73.98212946,
-      40.76534122
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000184",
-    "coordinates": [
-      -73.98821846,
-      40.74853941
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000185",
-    "coordinates": [
-      -73.98779173,
-      40.75009208
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000186",
-    "coordinates": [
-      -73.98873983,
-      40.73414765
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000189",
-    "coordinates": [
-      -73.98941209,
-      40.73414056
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000190",
-    "coordinates": [
-      -73.99342438,
-      40.73611052
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000191",
-    "coordinates": [
-      -73.99684066,
-      40.73756051
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000193",
-    "coordinates": [
-      -73.99360102,
-      40.73620058
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000194",
-    "coordinates": [
-      -73.98977798,
-      40.73412708
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000198",
-    "coordinates": [
-      -73.99831928,
-      40.73807416
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000199",
-    "coordinates": [
-      -74.0009461,
-      40.73899661
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000202",
-    "coordinates": [
-      -73.99993241,
-      40.73857046
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000203",
-    "coordinates": [
-      -73.998106,
-      40.737805
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000205",
-    "coordinates": [
-      -73.99947574,
-      40.73866726
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000206",
-    "coordinates": [
-      -73.99792058,
-      40.73790583
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000213",
-    "coordinates": [
-      -74.00400454,
-      40.74302673
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000214",
-    "coordinates": [
-      -73.9923767,
-      40.73803969
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000218",
-    "coordinates": [
-      -74.00416971,
-      40.74280314
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000220",
-    "coordinates": [
-      -73.99526424,
-      40.73933558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000221",
-    "coordinates": [
-      -73.99547509,
-      40.73943218
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000223",
-    "coordinates": [
-      -73.987162,
-      40.733107
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000224",
-    "coordinates": [
-      -73.98704351,
-      40.73369379
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000225",
-    "coordinates": [
-      -73.987384,
-      40.73347
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000226",
-    "coordinates": [
-      -73.98688143,
-      40.73391885
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000227",
-    "coordinates": [
-      -73.98663439,
-      40.73384075
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000228",
-    "coordinates": [
-      -73.98665825,
-      40.73422211
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000230",
-    "coordinates": [
-      -73.98617513,
-      40.73447281
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000231",
-    "coordinates": [
-      -73.980628,
-      40.742625
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000232",
-    "coordinates": [
-      -73.9763443,
-      40.74838329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000233",
-    "coordinates": [
-      -73.97653468,
-      40.74828704
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000235",
-    "coordinates": [
-      -73.96912972,
-      40.75827505
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000238",
-    "coordinates": [
-      -73.986488,
-      40.734031
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000240",
-    "coordinates": [
-      -73.982889,
-      40.739531
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000241",
-    "coordinates": [
-      -73.98625935,
-      40.73476963
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000242",
-    "coordinates": [
-      -73.98584567,
-      40.73534819
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000243",
-    "coordinates": [
-      -73.985322,
-      40.735626
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000246",
-    "coordinates": [
-      -73.98389,
-      40.737597
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000251",
-    "coordinates": [
-      -73.97408803,
-      40.75071654
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000252",
-    "coordinates": [
-      -73.96717705,
-      40.76020693
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000253",
-    "coordinates": [
-      -73.9849,
-      40.736214
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000254",
-    "coordinates": [
-      -73.985171,
-      40.735839
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000256",
-    "coordinates": [
-      -73.98512348,
-      40.73633169
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000257",
-    "coordinates": [
-      -73.98474973,
-      40.73642647
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000258",
-    "coordinates": [
-      -73.984486,
-      40.736789
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000264",
-    "coordinates": [
-      -73.982489,
-      40.739528
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000266",
-    "coordinates": [
-      -73.98242356,
-      40.74004081
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000267",
-    "coordinates": [
-      -73.98203484,
-      40.7399752
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000269",
-    "coordinates": [
-      -73.982383,
-      40.740246
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000270",
-    "coordinates": [
-      -73.98198848,
-      40.74021823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000272",
-    "coordinates": [
-      -73.981729,
-      40.740573
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000273",
-    "coordinates": [
-      -73.981576,
-      40.740775
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000274",
-    "coordinates": [
-      -73.98173228,
-      40.74098927
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000275",
-    "coordinates": [
-      -73.98151176,
-      40.74129079
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000276",
-    "coordinates": [
-      -73.98129694,
-      40.74116898
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000277",
-    "coordinates": [
-      -73.98133262,
-      40.74153614
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000278",
-    "coordinates": [
-      -73.98068,
-      40.742007
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000280",
-    "coordinates": [
-      -73.980371,
-      40.742433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000281",
-    "coordinates": [
-      -73.98045937,
-      40.742736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000283",
-    "coordinates": [
-      -73.98024173,
-      40.7430352
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000284",
-    "coordinates": [
-      -73.979813,
-      40.743093
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000285",
-    "coordinates": [
-      -73.97990736,
-      40.74349362
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000286",
-    "coordinates": [
-      -73.97965465,
-      40.74395034
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000287",
-    "coordinates": [
-      -73.979316,
-      40.743876
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000292",
-    "coordinates": [
-      -73.978416,
-      40.745116
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000296",
-    "coordinates": [
-      -73.977614,
-      40.746217
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000297",
-    "coordinates": [
-      -73.977444,
-      40.746449
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000298",
-    "coordinates": [
-      -73.97768758,
-      40.74653888
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000301",
-    "coordinates": [
-      -73.977005,
-      40.74705
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000302",
-    "coordinates": [
-      -73.976965,
-      40.747672
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000303",
-    "coordinates": [
-      -73.97677658,
-      40.74778786
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000304",
-    "coordinates": [
-      -73.976105,
-      40.748289
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000306",
-    "coordinates": [
-      -73.97602629,
-      40.7488188
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000308",
-    "coordinates": [
-      -73.97536339,
-      40.7487328
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000309",
-    "coordinates": [
-      -73.97518642,
-      40.74934112
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000310",
-    "coordinates": [
-      -73.975648,
-      40.748914
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000312",
-    "coordinates": [
-      -73.97510442,
-      40.74965755
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000313",
-    "coordinates": [
-      -73.974741,
-      40.750156
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000315",
-    "coordinates": [
-      -73.97488777,
-      40.75037797
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000316",
-    "coordinates": [
-      -73.97446736,
-      40.75095973
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000317",
-    "coordinates": [
-      -73.97414247,
-      40.75140578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000320",
-    "coordinates": [
-      -73.973765,
-      40.751497
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000326",
-    "coordinates": [
-      -73.97325385,
-      40.75262285
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000327",
-    "coordinates": [
-      -73.97284287,
-      40.75266482
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000328",
-    "coordinates": [
-      -73.972445,
-      40.753196
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000330",
-    "coordinates": [
-      -73.972868,
-      40.753149
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000331",
-    "coordinates": [
-      -73.972326,
-      40.753899
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000333",
-    "coordinates": [
-      -73.97218,
-      40.754092
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000334",
-    "coordinates": [
-      -73.97187609,
-      40.75451175
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000335",
-    "coordinates": [
-      -73.97103228,
-      40.75523348
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000336",
-    "coordinates": [
-      -73.97102968,
-      40.75587721
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000337",
-    "coordinates": [
-      -73.97125096,
-      40.75535623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000338",
-    "coordinates": [
-      -73.9701433,
-      40.75632633
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000339",
-    "coordinates": [
-      -73.97011147,
-      40.75650489
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000340",
-    "coordinates": [
-      -73.96981621,
-      40.75691135
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000341",
-    "coordinates": [
-      -73.97047,
-      40.756577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000342",
-    "coordinates": [
-      -73.97008839,
-      40.75711322
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000344",
-    "coordinates": [
-      -73.96961496,
-      40.75772905
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000346",
-    "coordinates": [
-      -73.96943631,
-      40.75785145
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000349",
-    "coordinates": [
-      -73.96895056,
-      40.7585484
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000350",
-    "coordinates": [
-      -73.968727,
-      40.758993
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000351",
-    "coordinates": [
-      -73.9687589,
-      40.75837712
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000352",
-    "coordinates": [
-      -73.96841698,
-      40.75881998
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000355",
-    "coordinates": [
-      -73.968242,
-      40.75961
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000357",
-    "coordinates": [
-      -73.968048,
-      40.759756
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000359",
-    "coordinates": [
-      -73.96756751,
-      40.76000519
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000360",
-    "coordinates": [
-      -73.96782751,
-      40.75963164
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000361",
-    "coordinates": [
-      -73.9677744,
-      40.76013485
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000362",
-    "coordinates": [
-      -73.96730567,
-      40.76034713
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000363",
-    "coordinates": [
-      -73.9675385,
-      40.76045676
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000364",
-    "coordinates": [
-      -73.96710117,
-      40.76064429
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000365",
-    "coordinates": [
-      -73.96677926,
-      40.76148352
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000366",
-    "coordinates": [
-      -73.96707578,
-      40.76109516
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000369",
-    "coordinates": [
-      -73.9663883,
-      40.76160412
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000371",
-    "coordinates": [
-      -73.98148039,
-      40.74148709
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000374",
-    "coordinates": [
-      -73.982886,
-      40.738827
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000375",
-    "coordinates": [
-      -73.979721,
-      40.766148
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000398",
-    "coordinates": [
-      -73.97719468,
-      40.76451317
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000419",
-    "coordinates": [
-      -73.98389868,
-      40.75495098
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000444",
-    "coordinates": [
-      -74.001807,
-      40.740531
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000447",
-    "coordinates": [
-      -74.00259998,
-      40.73944747
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000448",
-    "coordinates": [
-      -74.00137,
-      40.741123
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000449",
-    "coordinates": [
-      -74.00150114,
-      40.74137338
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000450",
-    "coordinates": [
-      -74.00132086,
-      40.74162142
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000451",
-    "coordinates": [
-      -74.001088,
-      40.74151
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000452",
-    "coordinates": [
-      -74.00071086,
-      40.74204648
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000453",
-    "coordinates": [
-      -74.00094,
-      40.742297
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000457",
-    "coordinates": [
-      -74.000238,
-      40.742689
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000458",
-    "coordinates": [
-      -73.982247,
-      40.767271
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000462",
-    "coordinates": [
-      -73.99989422,
-      40.7435787
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000463",
-    "coordinates": [
-      -73.9996452,
-      40.74391929
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000464",
-    "coordinates": [
-      -73.99939787,
-      40.74426003
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000465",
-    "coordinates": [
-      -73.998993,
-      40.744403
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000466",
-    "coordinates": [
-      -73.99915958,
-      40.74458405
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000468",
-    "coordinates": [
-      -73.998736,
-      40.74475
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000469",
-    "coordinates": [
-      -73.996434,
-      40.747905
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000471",
-    "coordinates": [
-      -73.99852935,
-      40.74503873
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000472",
-    "coordinates": [
-      -73.985061,
-      40.763424
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000473",
-    "coordinates": [
-      -73.99861909,
-      40.74544348
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000475",
-    "coordinates": [
-      -73.989409,
-      40.757544
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000480",
-    "coordinates": [
-      -73.989252,
-      40.757753
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000483",
-    "coordinates": [
-      -73.99775661,
-      40.74592407
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000484",
-    "coordinates": [
-      -73.98309182,
-      40.76663812
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000486",
-    "coordinates": [
-      -73.98315529,
-      40.76693979
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000487",
-    "coordinates": [
-      -73.98285321,
-      40.76696325
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000489",
-    "coordinates": [
-      -73.99233961,
-      40.75413992
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000491",
-    "coordinates": [
-      -73.98583017,
-      40.76305136
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000493",
-    "coordinates": [
-      -73.99712687,
-      40.74737717
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000496",
-    "coordinates": [
-      -73.995553,
-      40.749122
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000498",
-    "coordinates": [
-      -73.98256354,
-      40.76735759
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000499",
-    "coordinates": [
-      -73.995245,
-      40.749537
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000500",
-    "coordinates": [
-      -73.99511,
-      40.749728
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000501",
-    "coordinates": [
-      -73.99552538,
-      40.74982748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000502",
-    "coordinates": [
-      -73.994993,
-      40.74988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000503",
-    "coordinates": [
-      -73.99505137,
-      40.75022678
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000505",
-    "coordinates": [
-      -73.99275642,
-      40.75269979
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000508",
-    "coordinates": [
-      -73.992762,
-      40.752949
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000509",
-    "coordinates": [
-      -73.99294717,
-      40.75310732
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000511",
-    "coordinates": [
-      -73.9927184,
-      40.75342475
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000513",
-    "coordinates": [
-      -73.99256281,
-      40.75364209
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000516",
-    "coordinates": [
-      -73.991871,
-      40.754171
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000518",
-    "coordinates": [
-      -73.99181602,
-      40.75466587
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000520",
-    "coordinates": [
-      -73.99166162,
-      40.75488084
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000522",
-    "coordinates": [
-      -73.99137086,
-      40.75528084
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000524",
-    "coordinates": [
-      -73.991425,
-      40.7555
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000525",
-    "coordinates": [
-      -73.99093285,
-      40.75587809
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000527",
-    "coordinates": [
-      -73.98890049,
-      40.75866608
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000528",
-    "coordinates": [
-      -73.98877954,
-      40.75883097
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000529",
-    "coordinates": [
-      -73.98857946,
-      40.75910666
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000531",
-    "coordinates": [
-      -73.98818717,
-      40.75922149
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000532",
-    "coordinates": [
-      -74.00273531,
-      40.73967748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000533",
-    "coordinates": [
-      -73.98725149,
-      40.76107343
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000535",
-    "coordinates": [
-      -73.986828,
-      40.761094
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000537",
-    "coordinates": [
-      -74.002305,
-      40.739846
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000538",
-    "coordinates": [
-      -74.00221656,
-      40.73971856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000539",
-    "coordinates": [
-      -73.98629301,
-      40.76224616
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000540",
-    "coordinates": [
-      -73.986052,
-      40.762151
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000541",
-    "coordinates": [
-      -73.985923,
-      40.762331
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000544",
-    "coordinates": [
-      -73.98515741,
-      40.76380275
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000549",
-    "coordinates": [
-      -73.984767,
-      40.764338
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000550",
-    "coordinates": [
-      -73.98422945,
-      40.76464619
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000551",
-    "coordinates": [
-      -73.98454459,
-      40.76421225
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000552",
-    "coordinates": [
-      -73.98447,
-      40.764744
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000553",
-    "coordinates": [
-      -73.98409944,
-      40.76482318
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000554",
-    "coordinates": [
-      -73.98433343,
-      40.76493291
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000555",
-    "coordinates": [
-      -73.983593,
-      40.765522
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000556",
-    "coordinates": [
-      -73.98384519,
-      40.76560072
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000558",
-    "coordinates": [
-      -73.98354761,
-      40.76601142
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000560",
-    "coordinates": [
-      -73.98751478,
-      40.76056304
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000562",
-    "coordinates": [
-      -73.98811386,
-      40.75974624
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000563",
-    "coordinates": [
-      -73.98615577,
-      40.76243064
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000564",
-    "coordinates": [
-      -73.987313,
-      40.760283
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000566",
-    "coordinates": [
-      -73.986836,
-      40.760895
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000567",
-    "coordinates": [
-      -73.986606,
-      40.761816
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000568",
-    "coordinates": [
-      -73.98797229,
-      40.75993686
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000569",
-    "coordinates": [
-      -73.98778563,
-      40.75966968
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000570",
-    "coordinates": [
-      -74.00718506,
-      40.7157269
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-000600",
-    "coordinates": [
-      -73.9842789,
-      40.7403098
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000601",
-    "coordinates": [
-      -73.98392453,
-      40.74009245
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000603",
-    "coordinates": [
-      -73.98376711,
-      40.7410117
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000606",
-    "coordinates": [
-      -73.983198,
-      40.741481
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000612",
-    "coordinates": [
-      -73.983048,
-      40.742139
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000626",
-    "coordinates": [
-      -73.97036918,
-      40.7598074
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000634",
-    "coordinates": [
-      -73.981797,
-      40.743229
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000636",
-    "coordinates": [
-      -73.96867055,
-      40.76063098
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000637",
-    "coordinates": [
-      -73.97471723,
-      40.75263649
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000638",
-    "coordinates": [
-      -73.98203855,
-      40.74338446
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000649",
-    "coordinates": [
-      -73.98037405,
-      40.7450706
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000650",
-    "coordinates": [
-      -73.9799974,
-      40.74559121
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000652",
-    "coordinates": [
-      -73.98003507,
-      40.74582381
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000653",
-    "coordinates": [
-      -73.9802333,
-      40.74586329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000658",
-    "coordinates": [
-      -73.9771946,
-      40.74950281
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000660",
-    "coordinates": [
-      -73.9767944,
-      40.75013253
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000662",
-    "coordinates": [
-      -73.97651851,
-      40.7500145
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000663",
-    "coordinates": [
-      -73.9770118,
-      40.75027937
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000666",
-    "coordinates": [
-      -73.97681673,
-      40.75083273
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000679",
-    "coordinates": [
-      -73.97327607,
-      40.7550884
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000684",
-    "coordinates": [
-      -73.97126273,
-      40.75679025
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000686",
-    "coordinates": [
-      -73.97170313,
-      40.75779319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000692",
-    "coordinates": [
-      -73.97007156,
-      40.75980064
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000697",
-    "coordinates": [
-      -73.96880182,
-      40.76173086
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000698",
-    "coordinates": [
-      -73.96839056,
-      40.76155923
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000700",
-    "coordinates": [
-      -73.9823716,
-      40.74832255
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000703",
-    "coordinates": [
-      -73.97220317,
-      40.76232437
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000711",
-    "coordinates": [
-      -73.9815598,
-      40.74983207
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000712",
-    "coordinates": [
-      -73.98123607,
-      40.74998234
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000726",
-    "coordinates": [
-      -73.97973824,
-      40.75233526
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000727",
-    "coordinates": [
-      -73.9795852,
-      40.75254482
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000731",
-    "coordinates": [
-      -73.97924601,
-      40.75300305
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000742",
-    "coordinates": [
-      -73.97652976,
-      40.75674218
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000748",
-    "coordinates": [
-      -73.97534075,
-      40.75863294
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000749",
-    "coordinates": [
-      -73.97514297,
-      40.75864931
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000752",
-    "coordinates": [
-      -73.974008,
-      40.759712
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000753",
-    "coordinates": [
-      -73.9736332,
-      40.76024945
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000755",
-    "coordinates": [
-      -73.97310142,
-      40.76096333
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000756",
-    "coordinates": [
-      -73.97274462,
-      40.76151071
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000758",
-    "coordinates": [
-      -73.97235756,
-      40.76246695
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000761",
-    "coordinates": [
-      -73.971424,
-      40.763742
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000763",
-    "coordinates": [
-      -74.00998457,
-      40.70331108
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000771",
-    "coordinates": [
-      -74.00908241,
-      40.7039098
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000772",
-    "coordinates": [
-      -74.00732188,
-      40.70504418
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000774",
-    "coordinates": [
-      -74.00624351,
-      40.70624185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000779",
-    "coordinates": [
-      -73.95373886,
-      40.74355856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000780",
-    "coordinates": [
-      -73.807661,
-      40.701827
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000781",
-    "coordinates": [
-      -73.806477,
-      40.701853
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000783",
-    "coordinates": [
-      -73.80035218,
-      40.70345249
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000784",
-    "coordinates": [
-      -73.79869023,
-      40.70402028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000785",
-    "coordinates": [
-      -73.799923,
-      40.703352
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000789",
-    "coordinates": [
-      -73.79365361,
-      40.70584719
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000791",
-    "coordinates": [
-      -73.795897,
-      40.705143
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000793",
-    "coordinates": [
-      -73.79375474,
-      40.70599343
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000794",
-    "coordinates": [
-      -73.80201889,
-      40.70273351
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000797",
-    "coordinates": [
-      -73.79934332,
-      40.70376856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000798",
-    "coordinates": [
-      -73.79901751,
-      40.70389528
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000799",
-    "coordinates": [
-      -73.79847028,
-      40.7039284
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000801",
-    "coordinates": [
-      -73.79786531,
-      40.7043551
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000802",
-    "coordinates": [
-      -73.79774312,
-      40.70421585
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000804",
-    "coordinates": [
-      -73.79680056,
-      40.70460911
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000805",
-    "coordinates": [
-      -73.79662039,
-      40.70468655
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000824",
-    "coordinates": [
-      -73.96580928,
-      40.76210714
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000825",
-    "coordinates": [
-      -73.965443,
-      40.762896
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000826",
-    "coordinates": [
-      -73.965653,
-      40.763037
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000827",
-    "coordinates": [
-      -73.96407554,
-      40.76465351
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000828",
-    "coordinates": [
-      -73.96404982,
-      40.76483327
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000830",
-    "coordinates": [
-      -73.96318025,
-      40.76590165
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000832",
-    "coordinates": [
-      -73.963554,
-      40.76606
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000833",
-    "coordinates": [
-      -73.96313599,
-      40.76658802
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000834",
-    "coordinates": [
-      -73.96252262,
-      40.76733135
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000835",
-    "coordinates": [
-      -73.96228982,
-      40.76723406
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000836",
-    "coordinates": [
-      -73.961971,
-      40.767655
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000837",
-    "coordinates": [
-      -73.96225464,
-      40.76785489
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000838",
-    "coordinates": [
-      -73.96132436,
-      40.76910162
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000839",
-    "coordinates": [
-      -73.96096732,
-      40.76893883
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000842",
-    "coordinates": [
-      -73.960254,
-      40.770545
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000843",
-    "coordinates": [
-      -73.959928,
-      40.770456
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000845",
-    "coordinates": [
-      -73.959496,
-      40.770946
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000849",
-    "coordinates": [
-      -73.958697,
-      40.772144
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000850",
-    "coordinates": [
-      -73.95854022,
-      40.77235777
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000851",
-    "coordinates": [
-      -73.95895916,
-      40.77237577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000852",
-    "coordinates": [
-      -73.95876684,
-      40.7724771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000853",
-    "coordinates": [
-      -73.958474,
-      40.773003
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000854",
-    "coordinates": [
-      -73.95822043,
-      40.77281462
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000857",
-    "coordinates": [
-      -73.957965,
-      40.773727
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000858",
-    "coordinates": [
-      -73.957499,
-      40.774207
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000860",
-    "coordinates": [
-      -73.95709,
-      40.77435
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000862",
-    "coordinates": [
-      -73.956665,
-      40.774855
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000864",
-    "coordinates": [
-      -73.95593074,
-      40.77636605
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000865",
-    "coordinates": [
-      -73.955586,
-      40.776833
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000867",
-    "coordinates": [
-      -73.95513841,
-      40.77703019
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000868",
-    "coordinates": [
-      -73.954752,
-      40.777561
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000869",
-    "coordinates": [
-      -73.955153,
-      40.777528
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000870",
-    "coordinates": [
-      -73.954541,
-      40.778272
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000871",
-    "coordinates": [
-      -73.954428,
-      40.778003
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000872",
-    "coordinates": [
-      -73.97425395,
-      40.76298745
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000877",
-    "coordinates": [
-      -73.95399,
-      40.7786
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000878",
-    "coordinates": [
-      -73.95371545,
-      40.77860514
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000879",
-    "coordinates": [
-      -73.953663,
-      40.778792
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000880",
-    "coordinates": [
-      -73.95398,
-      40.779038
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000882",
-    "coordinates": [
-      -73.953715,
-      40.779535
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000883",
-    "coordinates": [
-      -73.953327,
-      40.779367
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000885",
-    "coordinates": [
-      -73.953537,
-      40.779635
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000886",
-    "coordinates": [
-      -73.9524,
-      40.780782
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000887",
-    "coordinates": [
-      -73.952279,
-      40.781503
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000888",
-    "coordinates": [
-      -73.951699,
-      40.782159
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000889",
-    "coordinates": [
-      -73.95125729,
-      40.78276562
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000890",
-    "coordinates": [
-      -73.9505618,
-      40.78328877
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000891",
-    "coordinates": [
-      -73.94987392,
-      40.78466254
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000892",
-    "coordinates": [
-      -73.94903127,
-      40.78581769
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000893",
-    "coordinates": [
-      -73.947944,
-      40.787309
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000896",
-    "coordinates": [
-      -73.946262,
-      40.789608
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000897",
-    "coordinates": [
-      -73.945683,
-      40.790401
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000898",
-    "coordinates": [
-      -73.945348,
-      40.790862
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000899",
-    "coordinates": [
-      -73.94489482,
-      40.79148064
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000900",
-    "coordinates": [
-      -73.94421805,
-      40.7912824
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000901",
-    "coordinates": [
-      -73.94423011,
-      40.79239362
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000902",
-    "coordinates": [
-      -73.94398813,
-      40.7922967
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000903",
-    "coordinates": [
-      -73.94378353,
-      40.7930088
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000904",
-    "coordinates": [
-      -73.94285894,
-      40.79427312
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000905",
-    "coordinates": [
-      -73.94239654,
-      40.79491138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000906",
-    "coordinates": [
-      -73.940337,
-      40.797303
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000907",
-    "coordinates": [
-      -73.94025621,
-      40.79783525
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000908",
-    "coordinates": [
-      -73.940035,
-      40.797709
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000909",
-    "coordinates": [
-      -73.94003626,
-      40.79813946
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000911",
-    "coordinates": [
-      -73.937249,
-      40.80154018
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000912",
-    "coordinates": [
-      -73.93728907,
-      40.80189861
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000913",
-    "coordinates": [
-      -73.93673443,
-      40.8026609
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000914",
-    "coordinates": [
-      -73.93627,
-      40.80287
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000915",
-    "coordinates": [
-      -73.93610685,
-      40.80351567
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000916",
-    "coordinates": [
-      -73.936139,
-      40.803731
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000918",
-    "coordinates": [
-      -73.96358324,
-      40.76587983
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000919",
-    "coordinates": [
-      -73.98184115,
-      40.76956574
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000920",
-    "coordinates": [
-      -73.98192926,
-      40.76981619
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000922",
-    "coordinates": [
-      -73.98250198,
-      40.76983868
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000924",
-    "coordinates": [
-      -73.98193,
-      40.773806
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000926",
-    "coordinates": [
-      -73.98200508,
-      40.77472311
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000927",
-    "coordinates": [
-      -73.982388,
-      40.774913
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000928",
-    "coordinates": [
-      -73.982571,
-      40.774894
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000929",
-    "coordinates": [
-      -73.98251236,
-      40.77475903
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000930",
-    "coordinates": [
-      -73.98239982,
-      40.77464584
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000932",
-    "coordinates": [
-      -73.98182879,
-      40.77539028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000933",
-    "coordinates": [
-      -73.981973,
-      40.775532
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000934",
-    "coordinates": [
-      -73.98235021,
-      40.77579496
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000936",
-    "coordinates": [
-      -73.98196294,
-      40.77600984
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000937",
-    "coordinates": [
-      -73.98193739,
-      40.77631103
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000938",
-    "coordinates": [
-      -73.98232347,
-      40.77662556
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-000939",
-    "coordinates": [
-      -73.98242959,
-      40.77647319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000942",
-    "coordinates": [
-      -73.98190427,
-      40.77713717
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000944",
-    "coordinates": [
-      -73.98225464,
-      40.77814804
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000945",
-    "coordinates": [
-      -73.98217819,
-      40.77860683
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000946",
-    "coordinates": [
-      -73.98205439,
-      40.77909594
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000947",
-    "coordinates": [
-      -73.98198995,
-      40.77933083
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000949",
-    "coordinates": [
-      -73.98139599,
-      40.78001947
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000951",
-    "coordinates": [
-      -73.98131051,
-      40.78032124
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000952",
-    "coordinates": [
-      -73.98117276,
-      40.78082575
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000954",
-    "coordinates": [
-      -73.98157091,
-      40.78081899
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000955",
-    "coordinates": [
-      -73.98152267,
-      40.78099279
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000957",
-    "coordinates": [
-      -73.980961,
-      40.781474
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000958",
-    "coordinates": [
-      -73.98080903,
-      40.78170535
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000959",
-    "coordinates": [
-      -73.98083572,
-      40.78185329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000960",
-    "coordinates": [
-      -73.981184,
-      40.781984
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000962",
-    "coordinates": [
-      -73.9804764,
-      40.78228509
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-000963",
-    "coordinates": [
-      -73.98058629,
-      40.78252808
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000966",
-    "coordinates": [
-      -73.98070878,
-      40.78312136
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000967",
-    "coordinates": [
-      -73.9808485,
-      40.78325962
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000968",
-    "coordinates": [
-      -73.980253,
-      40.783191
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000969",
-    "coordinates": [
-      -73.980123,
-      40.783373
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000970",
-    "coordinates": [
-      -73.97975218,
-      40.78364875
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000971",
-    "coordinates": [
-      -73.979708,
-      40.78392
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000972",
-    "coordinates": [
-      -73.979996,
-      40.784128
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000973",
-    "coordinates": [
-      -73.9797962,
-      40.78442303
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-000974",
-    "coordinates": [
-      -73.97977572,
-      40.78460807
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000975",
-    "coordinates": [
-      -73.979564,
-      40.784712
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000976",
-    "coordinates": [
-      -73.979224,
-      40.784564
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000978",
-    "coordinates": [
-      -73.97880715,
-      40.78502125
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000979",
-    "coordinates": [
-      -73.97863267,
-      40.78506849
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000981",
-    "coordinates": [
-      -73.97924562,
-      40.78513453
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000983",
-    "coordinates": [
-      -73.97878535,
-      40.78575329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000985",
-    "coordinates": [
-      -73.97829312,
-      40.78581305
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000986",
-    "coordinates": [
-      -73.97843851,
-      40.78561298
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000987",
-    "coordinates": [
-      -73.97799347,
-      40.78622273
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000989",
-    "coordinates": [
-      -73.977698,
-      40.786207
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000990",
-    "coordinates": [
-      -73.97776529,
-      40.78651948
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000991",
-    "coordinates": [
-      -73.9783,
-      40.786403
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000992",
-    "coordinates": [
-      -73.977832,
-      40.787028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000994",
-    "coordinates": [
-      -73.97764565,
-      40.78724687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000995",
-    "coordinates": [
-      -73.97748309,
-      40.78689604
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-000997",
-    "coordinates": [
-      -73.97655103,
-      40.78800168
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001006",
-    "coordinates": [
-      -73.926847,
-      40.819886
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001009",
-    "coordinates": [
-      -73.99218679,
-      40.69934194
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001010",
-    "coordinates": [
-      -73.99302857,
-      40.69758777
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001011",
-    "coordinates": [
-      -73.99126379,
-      40.69607044
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001017",
-    "coordinates": [
-      -73.98638427,
-      40.69123398
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001032",
-    "coordinates": [
-      -73.984481,
-      40.690588
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001043",
-    "coordinates": [
-      -73.997387,
-      40.660871
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001045",
-    "coordinates": [
-      -73.998822,
-      40.659902
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001046",
-    "coordinates": [
-      -73.99898564,
-      40.65974544
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001048",
-    "coordinates": [
-      -74.002446,
-      40.656011
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001049",
-    "coordinates": [
-      -74.00525819,
-      40.65371111
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001059",
-    "coordinates": [
-      -73.992259,
-      40.662588
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001076",
-    "coordinates": [
-      -73.96286903,
-      40.673692
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001078",
-    "coordinates": [
-      -73.960581,
-      40.660852
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001080",
-    "coordinates": [
-      -73.960426,
-      40.658911
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001087",
-    "coordinates": [
-      -73.94651287,
-      40.65102676
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001089",
-    "coordinates": [
-      -73.9439693,
-      40.65104682
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001091",
-    "coordinates": [
-      -73.940166,
-      40.651341
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001108",
-    "coordinates": [
-      -73.8362804,
-      40.69756287
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001109",
-    "coordinates": [
-      -73.83383439,
-      40.69889972
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001111",
-    "coordinates": [
-      -73.83160899,
-      40.69975447
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001112",
-    "coordinates": [
-      -73.8311312,
-      40.69988783
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001113",
-    "coordinates": [
-      -73.83093211,
-      40.69984112
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001114",
-    "coordinates": [
-      -73.8309137,
-      40.70015865
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001115",
-    "coordinates": [
-      -73.82655102,
-      40.70086445
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001116",
-    "coordinates": [
-      -73.82620488,
-      40.70092643
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001117",
-    "coordinates": [
-      -73.824719,
-      40.70104
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001122",
-    "coordinates": [
-      -73.82980897,
-      40.71316697
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001123",
-    "coordinates": [
-      -73.836262,
-      40.717664
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001125",
-    "coordinates": [
-      -73.839741,
-      40.719293
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001129",
-    "coordinates": [
-      -73.84488371,
-      40.72152582
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001130",
-    "coordinates": [
-      -73.852197,
-      40.726082
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001131",
-    "coordinates": [
-      -73.85251864,
-      40.72624127
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001134",
-    "coordinates": [
-      -73.858076,
-      40.728299
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001140",
-    "coordinates": [
-      -73.87470458,
-      40.73454516
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001141",
-    "coordinates": [
-      -73.87546,
-      40.734923
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001144",
-    "coordinates": [
-      -73.88093968,
-      40.73720596
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001147",
-    "coordinates": [
-      -73.886253,
-      40.738208
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001149",
-    "coordinates": [
-      -73.904656,
-      40.741288
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001152",
-    "coordinates": [
-      -73.91854,
-      40.742912
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001154",
-    "coordinates": [
-      -73.9206815,
-      40.74306271
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001155",
-    "coordinates": [
-      -73.921257,
-      40.743221
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001159",
-    "coordinates": [
-      -73.926455,
-      40.743823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001160",
-    "coordinates": [
-      -73.92692611,
-      40.74387741
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001161",
-    "coordinates": [
-      -73.927772,
-      40.743976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001194",
-    "coordinates": [
-      -73.929829,
-      40.744151
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001195",
-    "coordinates": [
-      -73.930399,
-      40.744278
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001290",
-    "coordinates": [
-      -73.9516172,
-      40.74318379
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001353",
-    "coordinates": [
-      -73.89719293,
-      40.86732884
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001354",
-    "coordinates": [
-      -73.89764488,
-      40.86737055
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001355",
-    "coordinates": [
-      -73.929992,
-      40.75191
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001356",
-    "coordinates": [
-      -73.927493,
-      40.751953
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001357",
-    "coordinates": [
-      -73.91232033,
-      40.75336987
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001359",
-    "coordinates": [
-      -73.90009406,
-      40.75391039
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001362",
-    "coordinates": [
-      -73.893639,
-      40.754507
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001363",
-    "coordinates": [
-      -73.915848,
-      40.839445
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001364",
-    "coordinates": [
-      -73.905076,
-      40.853028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001365",
-    "coordinates": [
-      -73.901091,
-      40.857756
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001473",
-    "coordinates": [
-      -73.881778,
-      40.755835
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001481",
-    "coordinates": [
-      -73.975391,
-      40.789424
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001482",
-    "coordinates": [
-      -73.97504101,
-      40.78945727
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001484",
-    "coordinates": [
-      -73.974767,
-      40.790053
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001486",
-    "coordinates": [
-      -73.974793,
-      40.790235
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001487",
-    "coordinates": [
-      -73.974462,
-      40.79069
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001488",
-    "coordinates": [
-      -73.97430229,
-      40.79090129
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001490",
-    "coordinates": [
-      -73.97481,
-      40.790818
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001492",
-    "coordinates": [
-      -73.973822,
-      40.791401
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001495",
-    "coordinates": [
-      -73.973425,
-      40.791943
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001496",
-    "coordinates": [
-      -73.973761,
-      40.792255
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001497",
-    "coordinates": [
-      -73.97312473,
-      40.79253447
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001498",
-    "coordinates": [
-      -73.97343761,
-      40.79269555
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001499",
-    "coordinates": [
-      -73.97328857,
-      40.79288708
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001500",
-    "coordinates": [
-      -73.97304342,
-      40.79342581
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001501",
-    "coordinates": [
-      -73.97264858,
-      40.79318087
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001502",
-    "coordinates": [
-      -73.97203479,
-      40.79382166
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001503",
-    "coordinates": [
-      -73.97256708,
-      40.79404227
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001504",
-    "coordinates": [
-      -73.97157309,
-      40.79446154
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001505",
-    "coordinates": [
-      -73.97185626,
-      40.79489566
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001507",
-    "coordinates": [
-      -73.971048,
-      40.795171
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001539",
-    "coordinates": [
-      -73.9707519,
-      40.7957738
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001540",
-    "coordinates": [
-      -73.970931,
-      40.796138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001542",
-    "coordinates": [
-      -73.970619,
-      40.796566
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001543",
-    "coordinates": [
-      -73.97065155,
-      40.79676125
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001545",
-    "coordinates": [
-      -73.97027901,
-      40.79642525
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001546",
-    "coordinates": [
-      -73.9696072,
-      40.79714851
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001547",
-    "coordinates": [
-      -73.96965239,
-      40.79728379
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001548",
-    "coordinates": [
-      -73.970011,
-      40.797394
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-001552",
-    "coordinates": [
-      -73.96924393,
-      40.79770166
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001553",
-    "coordinates": [
-      -73.969557,
-      40.798018
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001554",
-    "coordinates": [
-      -73.969093,
-      40.79865
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001555",
-    "coordinates": [
-      -73.96880907,
-      40.79904235
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001556",
-    "coordinates": [
-      -73.968326,
-      40.798954
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001557",
-    "coordinates": [
-      -73.96823224,
-      40.79933067
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001558",
-    "coordinates": [
-      -73.96796962,
-      40.7996299
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001594",
-    "coordinates": [
-      -73.96783287,
-      40.80030025
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001595",
-    "coordinates": [
-      -73.967782,
-      40.800581
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001596",
-    "coordinates": [
-      -73.96826,
-      40.800681
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-001597",
-    "coordinates": [
-      -73.96818631,
-      40.80047593
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001599",
-    "coordinates": [
-      -73.967707,
-      40.801084
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001600",
-    "coordinates": [
-      -73.967493,
-      40.802126
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001601",
-    "coordinates": [
-      -73.967585,
-      40.802298
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001602",
-    "coordinates": [
-      -73.968149,
-      40.802455
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001603",
-    "coordinates": [
-      -73.967461,
-      40.802736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001604",
-    "coordinates": [
-      -73.967379,
-      40.802944
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001605",
-    "coordinates": [
-      -73.967381,
-      40.803721
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001606",
-    "coordinates": [
-      -73.96670754,
-      40.80386123
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001607",
-    "coordinates": [
-      -73.96657376,
-      40.80464541
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-001608",
-    "coordinates": [
-      -73.96678806,
-      40.80511381
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-001609",
-    "coordinates": [
-      -73.9659025,
-      40.80495915
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001610",
-    "coordinates": [
-      -73.96566952,
-      40.80527964
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001612",
-    "coordinates": [
-      -73.9655261,
-      40.80547204
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001675",
-    "coordinates": [
-      -73.97414806,
-      40.75096552
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001676",
-    "coordinates": [
-      -73.965081,
-      40.805923
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001677",
-    "coordinates": [
-      -73.95579589,
-      40.81881338
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001678",
-    "coordinates": [
-      -73.95526804,
-      40.82027959
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001680",
-    "coordinates": [
-      -73.95480753,
-      40.82076419
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001682",
-    "coordinates": [
-      -73.953676,
-      40.822319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001683",
-    "coordinates": [
-      -73.953007,
-      40.822495
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001684",
-    "coordinates": [
-      -73.953041,
-      40.823326
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001685",
-    "coordinates": [
-      -73.95258142,
-      40.82382134
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001688",
-    "coordinates": [
-      -73.96421034,
-      40.80804124
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001689",
-    "coordinates": [
-      -73.964488,
-      40.807508
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001690",
-    "coordinates": [
-      -73.96464555,
-      40.80729581
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001691",
-    "coordinates": [
-      -73.965108,
-      40.80676
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001695",
-    "coordinates": [
-      -73.951597,
-      40.824559
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001696",
-    "coordinates": [
-      -73.9516557,
-      40.8250896
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001697",
-    "coordinates": [
-      -73.95148795,
-      40.82531855
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001699",
-    "coordinates": [
-      -73.950907,
-      40.825508
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001702",
-    "coordinates": [
-      -73.950482,
-      40.82609
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001703",
-    "coordinates": [
-      -73.95071631,
-      40.82637629
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001705",
-    "coordinates": [
-      -73.947868,
-      40.825446
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001706",
-    "coordinates": [
-      -73.947604,
-      40.825419
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001710",
-    "coordinates": [
-      -74.11216061,
-      40.56175506
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001712",
-    "coordinates": [
-      -74.11422426,
-      40.56585176
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001714",
-    "coordinates": [
-      -74.10965729,
-      40.57031185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001715",
-    "coordinates": [
-      -74.109918,
-      40.570635
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001716",
-    "coordinates": [
-      -74.11408666,
-      40.57285319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001749",
-    "coordinates": [
-      -74.103479,
-      40.576541
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001750",
-    "coordinates": [
-      -74.10231,
-      40.577771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001752",
-    "coordinates": [
-      -74.100732,
-      40.590983
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001756",
-    "coordinates": [
-      -74.08620985,
-      40.59545604
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001757",
-    "coordinates": [
-      -74.08262136,
-      40.59839673
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001773",
-    "coordinates": [
-      -73.89873,
-      40.867627
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001774",
-    "coordinates": [
-      -73.8995757,
-      40.86782871
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001777",
-    "coordinates": [
-      -73.90031404,
-      40.86231329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001780",
-    "coordinates": [
-      -73.902369,
-      40.86063
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001785",
-    "coordinates": [
-      -73.921747,
-      40.831467
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001786",
-    "coordinates": [
-      -73.92390599,
-      40.82765532
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001787",
-    "coordinates": [
-      -73.90555222,
-      40.85304298
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001788",
-    "coordinates": [
-      -73.905403,
-      40.853157
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001791",
-    "coordinates": [
-      -73.928165,
-      40.818676
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001792",
-    "coordinates": [
-      -73.92837,
-      40.818942
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001820",
-    "coordinates": [
-      -73.79220518,
-      40.70635736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001821",
-    "coordinates": [
-      -73.792368,
-      40.706507
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001824",
-    "coordinates": [
-      -73.830838,
-      40.713983
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-001827",
-    "coordinates": [
-      -73.833513,
-      40.715758
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002056",
-    "coordinates": [
-      -73.949868,
-      40.826928
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002057",
-    "coordinates": [
-      -73.95022615,
-      40.82704355
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002058",
-    "coordinates": [
-      -73.95002586,
-      40.82732011
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002059",
-    "coordinates": [
-      -73.949581,
-      40.827932
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002061",
-    "coordinates": [
-      -73.949288,
-      40.82758
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002062",
-    "coordinates": [
-      -73.949017,
-      40.828097
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002064",
-    "coordinates": [
-      -73.94913226,
-      40.82854185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002065",
-    "coordinates": [
-      -73.94886891,
-      40.82903713
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002066",
-    "coordinates": [
-      -73.948046,
-      40.829424
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002067",
-    "coordinates": [
-      -73.94764707,
-      40.82934138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002068",
-    "coordinates": [
-      -73.947866,
-      40.829675
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002069",
-    "coordinates": [
-      -73.948201,
-      40.829809
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002070",
-    "coordinates": [
-      -73.94791148,
-      40.83020903
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002072",
-    "coordinates": [
-      -73.947195,
-      40.830586
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002073",
-    "coordinates": [
-      -73.946986,
-      40.830876
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002074",
-    "coordinates": [
-      -73.94477152,
-      40.83391054
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002075",
-    "coordinates": [
-      -73.944329,
-      40.834513
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002076",
-    "coordinates": [
-      -73.944176,
-      40.834722
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002078",
-    "coordinates": [
-      -73.944011,
-      40.835546
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002079",
-    "coordinates": [
-      -73.943873,
-      40.835135
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002082",
-    "coordinates": [
-      -73.943186,
-      40.836081
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-002084",
-    "coordinates": [
-      -73.942787,
-      40.836501
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002118",
-    "coordinates": [
-      -73.942288,
-      40.837104
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002214",
-    "coordinates": [
-      -73.963959,
-      40.682932
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002234",
-    "coordinates": [
-      -73.97820169,
-      40.68788961
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002241",
-    "coordinates": [
-      -73.951381,
-      40.680556
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002337",
-    "coordinates": [
-      -73.943843,
-      40.680015
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002341",
-    "coordinates": [
-      -73.924424,
-      40.67896
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002342",
-    "coordinates": [
-      -73.927098,
-      40.679232
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002345",
-    "coordinates": [
-      -73.916507,
-      40.678654
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002347",
-    "coordinates": [
-      -73.911008,
-      40.678354
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002348",
-    "coordinates": [
-      -73.908374,
-      40.678079
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002351",
-    "coordinates": [
-      -73.869636,
-      40.684317
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002455",
-    "coordinates": [
-      -73.958717,
-      40.6688
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002456",
-    "coordinates": [
-      -73.95826142,
-      40.66965209
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002457",
-    "coordinates": [
-      -73.95817186,
-      40.67031776
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002525",
-    "coordinates": [
-      -73.98371008,
-      40.6886723
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002526",
-    "coordinates": [
-      -73.98247226,
-      40.68844943
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002528",
-    "coordinates": [
-      -73.98128393,
-      40.68781362
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002533",
-    "coordinates": [
-      -73.97637079,
-      40.68696059
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002667",
-    "coordinates": [
-      -73.989159,
-      40.665618
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002668",
-    "coordinates": [
-      -73.987979,
-      40.667305
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002670",
-    "coordinates": [
-      -73.97744609,
-      40.6807318
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002674",
-    "coordinates": [
-      -73.93187521,
-      40.74445002
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002677",
-    "coordinates": [
-      -74.00101556,
-      40.7180331
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002678",
-    "coordinates": [
-      -74.000962,
-      40.717828
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002679",
-    "coordinates": [
-      -74.00151938,
-      40.71748211
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002680",
-    "coordinates": [
-      -74.00173929,
-      40.71724104
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002681",
-    "coordinates": [
-      -74.002253,
-      40.716682
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002682",
-    "coordinates": [
-      -74.00257,
-      40.716033
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-002683",
-    "coordinates": [
-      -74.00266673,
-      40.71548409
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003010",
-    "coordinates": [
-      -73.99105603,
-      40.73389175
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003015",
-    "coordinates": [
-      -73.98592802,
-      40.73115701
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003226",
-    "coordinates": [
-      -73.985739,
-      40.73108
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003227",
-    "coordinates": [
-      -73.98638945,
-      40.73053706
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003228",
-    "coordinates": [
-      -73.985882,
-      40.730881
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003229",
-    "coordinates": [
-      -73.986348,
-      40.730249
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003230",
-    "coordinates": [
-      -73.987081,
-      40.729236
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003231",
-    "coordinates": [
-      -73.98791444,
-      40.72875565
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003232",
-    "coordinates": [
-      -73.98787592,
-      40.72848039
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003234",
-    "coordinates": [
-      -73.98781752,
-      40.72823169
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003235",
-    "coordinates": [
-      -73.987965,
-      40.728027
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003236",
-    "coordinates": [
-      -73.98812504,
-      40.72815774
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003237",
-    "coordinates": [
-      -73.98837167,
-      40.72745986
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003239",
-    "coordinates": [
-      -73.989248,
-      40.726263
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003240",
-    "coordinates": [
-      -73.98935062,
-      40.72647126
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003241",
-    "coordinates": [
-      -73.989403,
-      40.726049
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003242",
-    "coordinates": [
-      -73.989698,
-      40.725641
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003244",
-    "coordinates": [
-      -73.993343,
-      40.721716
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003247",
-    "coordinates": [
-      -73.99407509,
-      40.72059636
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003249",
-    "coordinates": [
-      -73.99406649,
-      40.71990707
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003263",
-    "coordinates": [
-      -74.005126,
-      40.715712
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-003268",
-    "coordinates": [
-      -74.0065117,
-      40.71420865
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-003308",
-    "coordinates": [
-      -73.985832,
-      40.758022
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003309",
-    "coordinates": [
-      -73.984342,
-      40.759971
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003311",
-    "coordinates": [
-      -73.984131,
-      40.759713
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003312",
-    "coordinates": [
-      -73.98369329,
-      40.76032636
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003313",
-    "coordinates": [
-      -73.9835375,
-      40.76052662
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003315",
-    "coordinates": [
-      -73.98309028,
-      40.76114197
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003316",
-    "coordinates": [
-      -73.982996,
-      40.76164
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003352",
-    "coordinates": [
-      -73.982552,
-      40.762366
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003354",
-    "coordinates": [
-      -73.981711,
-      40.763036
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003357",
-    "coordinates": [
-      -73.98047755,
-      40.7647181
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003358",
-    "coordinates": [
-      -73.98073089,
-      40.76487454
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003474",
-    "coordinates": [
-      -73.97104466,
-      40.79331
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003475",
-    "coordinates": [
-      -73.97088677,
-      40.7935244
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003477",
-    "coordinates": [
-      -73.970376,
-      40.793867
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-003478",
-    "coordinates": [
-      -73.97057117,
-      40.79396219
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003479",
-    "coordinates": [
-      -73.97005104,
-      40.79467259
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003480",
-    "coordinates": [
-      -73.969837,
-      40.794604
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003481",
-    "coordinates": [
-      -73.96981,
-      40.795005
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003482",
-    "coordinates": [
-      -73.96941887,
-      40.79554394
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003483",
-    "coordinates": [
-      -73.968849,
-      40.795951
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003799",
-    "coordinates": [
-      -73.968682,
-      40.796533
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003835",
-    "coordinates": [
-      -73.96864684,
-      40.79673748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003871",
-    "coordinates": [
-      -73.968542,
-      40.796374
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003872",
-    "coordinates": [
-      -73.96822346,
-      40.79717824
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003873",
-    "coordinates": [
-      -73.96807,
-      40.797391
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003874",
-    "coordinates": [
-      -73.96784046,
-      40.79770007
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003875",
-    "coordinates": [
-      -73.96774773,
-      40.79782619
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003911",
-    "coordinates": [
-      -73.96760332,
-      40.79802733
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003912",
-    "coordinates": [
-      -73.96726529,
-      40.79847664
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003914",
-    "coordinates": [
-      -73.981853,
-      40.777921
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003916",
-    "coordinates": [
-      -73.981665,
-      40.778381
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003917",
-    "coordinates": [
-      -73.966917,
-      40.803579
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-003918",
-    "coordinates": [
-      -73.965995,
-      40.804835
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004657",
-    "coordinates": [
-      -73.9668303,
-      40.79908844
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004661",
-    "coordinates": [
-      -73.949738,
-      40.827117
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004664",
-    "coordinates": [
-      -73.93878768,
-      40.84449293
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004809",
-    "coordinates": [
-      -73.96610661,
-      40.80050433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004812",
-    "coordinates": [
-      -73.96493891,
-      40.80104973
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-004816",
-    "coordinates": [
-      -73.958889,
-      40.809965
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004817",
-    "coordinates": [
-      -73.958744,
-      40.810163
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004818",
-    "coordinates": [
-      -73.958321,
-      40.810378
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004820",
-    "coordinates": [
-      -73.957517,
-      40.811845
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-004821",
-    "coordinates": [
-      -73.95618997,
-      40.81366899
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-004822",
-    "coordinates": [
-      -73.954837,
-      40.81515
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005208",
-    "coordinates": [
-      -73.95450726,
-      40.81559377
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005209",
-    "coordinates": [
-      -73.95436371,
-      40.8157996
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005211",
-    "coordinates": [
-      -73.952755,
-      40.818371
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005212",
-    "coordinates": [
-      -73.951942,
-      40.8196
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005213",
-    "coordinates": [
-      -73.950863,
-      40.82096
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005215",
-    "coordinates": [
-      -73.950118,
-      40.822212
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005216",
-    "coordinates": [
-      -73.9499056,
-      40.82226783
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005217",
-    "coordinates": [
-      -73.94964029,
-      40.82263345
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005218",
-    "coordinates": [
-      -73.94901382,
-      40.82312201
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005220",
-    "coordinates": [
-      -73.947909,
-      40.824646
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005221",
-    "coordinates": [
-      -73.94695314,
-      40.82594748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005400",
-    "coordinates": [
-      -74.11267359,
-      40.57210026
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005402",
-    "coordinates": [
-      -74.113383,
-      40.57262
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005407",
-    "coordinates": [
-      -74.116075,
-      40.563843
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005414",
-    "coordinates": [
-      -74.101669,
-      40.578802
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005418",
-    "coordinates": [
-      -74.10267054,
-      40.57739083
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005422",
-    "coordinates": [
-      -73.92921294,
-      40.81888599
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005426",
-    "coordinates": [
-      -73.92590252,
-      40.82755199
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005427",
-    "coordinates": [
-      -73.92522252,
-      40.82735593
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005430",
-    "coordinates": [
-      -73.9248328,
-      40.82782471
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005435",
-    "coordinates": [
-      -73.92264499,
-      40.831543
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005578",
-    "coordinates": [
-      -73.90070588,
-      40.86810029
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005579",
-    "coordinates": [
-      -73.896537,
-      40.867038
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005582",
-    "coordinates": [
-      -73.89565372,
-      40.86658827
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005725",
-    "coordinates": [
-      -73.9730618,
-      40.67758878
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005775",
-    "coordinates": [
-      -73.97183554,
-      40.67613405
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005779",
-    "coordinates": [
-      -73.962694,
-      40.672748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005782",
-    "coordinates": [
-      -73.963553,
-      40.675659
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005877",
-    "coordinates": [
-      -73.952134,
-      40.824578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005878",
-    "coordinates": [
-      -73.95349829,
-      40.82270396
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005879",
-    "coordinates": [
-      -73.95331,
-      40.821918
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005882",
-    "coordinates": [
-      -73.95937,
-      40.81450454
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005931",
-    "coordinates": [
-      -73.96605183,
-      40.80551623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005932",
-    "coordinates": [
-      -73.93635101,
-      40.80383418
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-005933",
-    "coordinates": [
-      -73.93646798,
-      40.80263697
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-006026",
-    "coordinates": [
-      -73.9390355,
-      40.79950465
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006027",
-    "coordinates": [
-      -73.94478351,
-      40.79120304
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006028",
-    "coordinates": [
-      -73.9389231,
-      40.79965855
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006029",
-    "coordinates": [
-      -73.95902951,
-      40.80941222
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006031",
-    "coordinates": [
-      -73.953007,
-      40.817656
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006032",
-    "coordinates": [
-      -73.94644065,
-      40.82719623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006033",
-    "coordinates": [
-      -73.946043,
-      40.827195
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006035",
-    "coordinates": [
-      -73.94375597,
-      40.83033563
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006037",
-    "coordinates": [
-      -73.942327,
-      40.832283
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006038",
-    "coordinates": [
-      -73.94226576,
-      40.83273107
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006039",
-    "coordinates": [
-      -73.94174,
-      40.833447
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006040",
-    "coordinates": [
-      -73.94144661,
-      40.83386084
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006041",
-    "coordinates": [
-      -73.94115905,
-      40.83424538
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006042",
-    "coordinates": [
-      -73.940919,
-      40.834078
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006043",
-    "coordinates": [
-      -73.94047731,
-      40.83481514
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006138",
-    "coordinates": [
-      -73.95745774,
-      40.672302
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006140",
-    "coordinates": [
-      -73.96361018,
-      40.67640751
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006141",
-    "coordinates": [
-      -73.98192018,
-      40.68745727
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006143",
-    "coordinates": [
-      -73.9879984,
-      40.69059444
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006150",
-    "coordinates": [
-      -73.96927886,
-      40.798538
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006197",
-    "coordinates": [
-      -73.925474,
-      40.679143
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006860",
-    "coordinates": [
-      -73.95447974,
-      40.74188244
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006861",
-    "coordinates": [
-      -73.838184,
-      40.718602
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006867",
-    "coordinates": [
-      -73.88571747,
-      40.73810857
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006873",
-    "coordinates": [
-      -73.84284541,
-      40.72067138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006876",
-    "coordinates": [
-      -73.838976,
-      40.718953
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006880",
-    "coordinates": [
-      -73.83680527,
-      40.71796031
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006882",
-    "coordinates": [
-      -73.83549622,
-      40.71721235
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006885",
-    "coordinates": [
-      -73.832341,
-      40.714861
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-006987",
-    "coordinates": [
-      -73.82816,
-      40.711072
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007082",
-    "coordinates": [
-      -73.98570283,
-      40.75786907
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007083",
-    "coordinates": [
-      -73.98587842,
-      40.75766558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007084",
-    "coordinates": [
-      -73.98663358,
-      40.75663815
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007085",
-    "coordinates": [
-      -73.98094971,
-      40.77426628
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007086",
-    "coordinates": [
-      -73.981404,
-      40.773657
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007136",
-    "coordinates": [
-      -73.95212666,
-      40.74291934
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007143",
-    "coordinates": [
-      -73.982777,
-      40.777227
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007144",
-    "coordinates": [
-      -73.98301515,
-      40.77653006
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007145",
-    "coordinates": [
-      -73.983247,
-      40.775999
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007147",
-    "coordinates": [
-      -73.98363296,
-      40.77606852
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007148",
-    "coordinates": [
-      -73.9793497,
-      40.76664932
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007149",
-    "coordinates": [
-      -73.98471931,
-      40.76399635
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007150",
-    "coordinates": [
-      -73.98498723,
-      40.76361577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007244",
-    "coordinates": [
-      -73.986581,
-      40.754144
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007299",
-    "coordinates": [
-      -73.9748182,
-      40.74930073
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007300",
-    "coordinates": [
-      -73.97332638,
-      40.74867273
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007302",
-    "coordinates": [
-      -73.973319,
-      40.748513
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007322",
-    "coordinates": [
-      -73.97296141,
-      40.74857853
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007628",
-    "coordinates": [
-      -73.972507,
-      40.749203
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007629",
-    "coordinates": [
-      -73.97275057,
-      40.74929182
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007631",
-    "coordinates": [
-      -73.97065717,
-      40.75163236
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007632",
-    "coordinates": [
-      -73.97052358,
-      40.75234297
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007634",
-    "coordinates": [
-      -73.969261,
-      40.753496
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007635",
-    "coordinates": [
-      -73.968836,
-      40.754138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007636",
-    "coordinates": [
-      -73.96855237,
-      40.75504319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007637",
-    "coordinates": [
-      -73.968444,
-      40.755193
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007638",
-    "coordinates": [
-      -73.968041,
-      40.755335
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007639",
-    "coordinates": [
-      -73.96746716,
-      40.75601841
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007870",
-    "coordinates": [
-      -73.96698,
-      40.75678
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007871",
-    "coordinates": [
-      -73.96652752,
-      40.75741739
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007872",
-    "coordinates": [
-      -73.96642136,
-      40.7579749
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-007876",
-    "coordinates": [
-      -73.958069,
-      40.773006
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008199",
-    "coordinates": [
-      -74.007972,
-      40.724065
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008200",
-    "coordinates": [
-      -74.00755377,
-      40.72533498
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008202",
-    "coordinates": [
-      -74.007487,
-      40.726889
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008203",
-    "coordinates": [
-      -74.00698658,
-      40.72797798
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008211",
-    "coordinates": [
-      -73.996012,
-      40.748482
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008212",
-    "coordinates": [
-      -74.00372466,
-      40.74341383
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008214",
-    "coordinates": [
-      -74.00436342,
-      40.74212485
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-008215",
-    "coordinates": [
-      -73.99407922,
-      40.73116016
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008221",
-    "coordinates": [
-      -73.98665837,
-      40.72983073
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008223",
-    "coordinates": [
-      -73.989008,
-      40.730578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008224",
-    "coordinates": [
-      -73.988685,
-      40.731015
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008225",
-    "coordinates": [
-      -73.98857914,
-      40.73157049
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008226",
-    "coordinates": [
-      -73.98813515,
-      40.73177664
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008227",
-    "coordinates": [
-      -73.987938,
-      40.732039
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008229",
-    "coordinates": [
-      -73.993454,
-      40.721425
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008230",
-    "coordinates": [
-      -73.99494009,
-      40.71791958
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008239",
-    "coordinates": [
-      -74.004974,
-      40.719679
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008245",
-    "coordinates": [
-      -73.98926217,
-      40.73023165
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008295",
-    "coordinates": [
-      -73.98985,
-      40.719215
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008296",
-    "coordinates": [
-      -73.9883901,
-      40.72357993
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008302",
-    "coordinates": [
-      -73.98532503,
-      40.72779351
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008303",
-    "coordinates": [
-      -73.985083,
-      40.728126
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008305",
-    "coordinates": [
-      -73.98468,
-      40.728824
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008307",
-    "coordinates": [
-      -73.98319263,
-      40.73030035
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008590",
-    "coordinates": [
-      -73.994742,
-      40.736387
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008689",
-    "coordinates": [
-      -73.99248875,
-      40.74861534
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008693",
-    "coordinates": [
-      -73.99100163,
-      40.74557814
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008694",
-    "coordinates": [
-      -73.991375,
-      40.744668
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008695",
-    "coordinates": [
-      -73.99403913,
-      40.74596848
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008696",
-    "coordinates": [
-      -73.99428583,
-      40.74615485
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008837",
-    "coordinates": [
-      -73.985367,
-      40.744742
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008838",
-    "coordinates": [
-      -73.984639,
-      40.745126
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008840",
-    "coordinates": [
-      -73.98620711,
-      40.74670887
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008842",
-    "coordinates": [
-      -73.98524463,
-      40.74711441
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-008843",
-    "coordinates": [
-      -73.98483344,
-      40.74773664
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-009081",
-    "coordinates": [
-      -73.980862,
-      40.689026
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-009082",
-    "coordinates": [
-      -73.9810645,
-      40.74688075
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-009918",
-    "coordinates": [
-      -73.99113025,
-      40.75048843
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010160",
-    "coordinates": [
-      -73.98401196,
-      40.76023532
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010161",
-    "coordinates": [
-      -73.98463666,
-      40.75937884
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010171",
-    "coordinates": [
-      -73.97699037,
-      40.7592052
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010173",
-    "coordinates": [
-      -73.97473228,
-      40.76246755
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010174",
-    "coordinates": [
-      -73.97119784,
-      40.76425414
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010177",
-    "coordinates": [
-      -73.96558891,
-      40.75868871
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010191",
-    "coordinates": [
-      -73.94648352,
-      40.800446
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010198",
-    "coordinates": [
-      -73.88597436,
-      40.84183354
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010208",
-    "coordinates": [
-      -73.92220947,
-      40.80890966
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010216",
-    "coordinates": [
-      -73.95278868,
-      40.80732567
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010251",
-    "coordinates": [
-      -73.90095411,
-      40.85054841
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010257",
-    "coordinates": [
-      -73.93780684,
-      40.84356713
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010258",
-    "coordinates": [
-      -73.93347331,
-      40.84985449
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010259",
-    "coordinates": [
-      -73.93100715,
-      40.85285737
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010260",
-    "coordinates": [
-      -73.93334198,
-      40.85003751
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010262",
-    "coordinates": [
-      -73.94948944,
-      40.81265566
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010265",
-    "coordinates": [
-      -73.93332247,
-      40.84969774
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010271",
-    "coordinates": [
-      -73.92940254,
-      40.85541608
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010274",
-    "coordinates": [
-      -73.9289967,
-      40.85561537
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010287",
-    "coordinates": [
-      -73.91021789,
-      40.85434622
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010297",
-    "coordinates": [
-      -73.996549,
-      40.74267426
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010317",
-    "coordinates": [
-      -73.907899,
-      40.853764
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010320",
-    "coordinates": [
-      -73.98809867,
-      40.76956734
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010328",
-    "coordinates": [
-      -73.95091962,
-      40.66416648
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010332",
-    "coordinates": [
-      -73.91917137,
-      40.81399752
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010336",
-    "coordinates": [
-      -73.92201908,
-      40.76047267
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010337",
-    "coordinates": [
-      -73.921216,
-      40.760095
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010338",
-    "coordinates": [
-      -73.91801561,
-      40.75859125
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010339",
-    "coordinates": [
-      -73.88507204,
-      40.7496063
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010340",
-    "coordinates": [
-      -73.91730276,
-      40.76490229
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010341",
-    "coordinates": [
-      -73.95184032,
-      40.80943715
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010345",
-    "coordinates": [
-      -73.950407,
-      40.805827
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010346",
-    "coordinates": [
-      -73.95170768,
-      40.8092681
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010349",
-    "coordinates": [
-      -73.94591692,
-      40.81197343
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010350",
-    "coordinates": [
-      -73.957067,
-      40.801938
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010356",
-    "coordinates": [
-      -73.9478767,
-      40.81486349
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010357",
-    "coordinates": [
-      -73.95214914,
-      40.80899649
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010360",
-    "coordinates": [
-      -73.951496,
-      40.725456
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010367",
-    "coordinates": [
-      -73.95282089,
-      40.77823256
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010368",
-    "coordinates": [
-      -73.91644985,
-      40.81876868
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010402",
-    "coordinates": [
-      -73.9601529,
-      40.76191027
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010405",
-    "coordinates": [
-      -73.93750775,
-      40.8240811
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010406",
-    "coordinates": [
-      -73.95141341,
-      40.81002334
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010430",
-    "coordinates": [
-      -73.88549761,
-      40.74753882
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010434",
-    "coordinates": [
-      -73.95052895,
-      40.70682217
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010440",
-    "coordinates": [
-      -73.845226,
-      40.695225
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010447",
-    "coordinates": [
-      -73.942908,
-      40.701419
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010448",
-    "coordinates": [
-      -73.94996349,
-      40.70537096
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010455",
-    "coordinates": [
-      -73.95419488,
-      40.70720786
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010460",
-    "coordinates": [
-      -73.91526202,
-      40.81792619
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010501",
-    "coordinates": [
-      -73.93059918,
-      40.76453793
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010558",
-    "coordinates": [
-      -73.92485555,
-      40.76164578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010567",
-    "coordinates": [
-      -73.95080928,
-      40.66734613
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010606",
-    "coordinates": [
-      -74.00677204,
-      40.71502742
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010610",
-    "coordinates": [
-      -73.97246279,
-      40.78577388
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010614",
-    "coordinates": [
-      -74.003811,
-      40.753067
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010615",
-    "coordinates": [
-      -74.00421615,
-      40.7529434
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010616",
-    "coordinates": [
-      -74.00475581,
-      40.75219823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010617",
-    "coordinates": [
-      -74.00491217,
-      40.75196913
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010618",
-    "coordinates": [
-      -74.0051459,
-      40.75123392
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010633",
-    "coordinates": [
-      -73.97340729,
-      40.78461205
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010634",
-    "coordinates": [
-      -73.97641054,
-      40.7887051
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010636",
-    "coordinates": [
-      -73.97518371,
-      40.78253997
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010637",
-    "coordinates": [
-      -73.97381614,
-      40.78442334
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010646",
-    "coordinates": [
-      -74.00581555,
-      40.75074558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010650",
-    "coordinates": [
-      -73.96397801,
-      40.75629836
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010664",
-    "coordinates": [
-      -73.97544551,
-      40.74559596
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010673",
-    "coordinates": [
-      -73.98324818,
-      40.74425922
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010675",
-    "coordinates": [
-      -73.97298135,
-      40.79030079
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010681",
-    "coordinates": [
-      -73.96770405,
-      40.79280441
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010682",
-    "coordinates": [
-      -73.96964431,
-      40.7895412
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010683",
-    "coordinates": [
-      -73.97262871,
-      40.78568185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010684",
-    "coordinates": [
-      -73.98581619,
-      40.74642561
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010696",
-    "coordinates": [
-      -73.97899987,
-      40.78240982
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010697",
-    "coordinates": [
-      -73.9599541,
-      40.77956091
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010703",
-    "coordinates": [
-      -73.96418188,
-      40.7562636
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010708",
-    "coordinates": [
-      -74.000048,
-      40.71819776
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010713",
-    "coordinates": [
-      -73.99248961,
-      40.71450806
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010715",
-    "coordinates": [
-      -73.96223547,
-      40.7636906
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010720",
-    "coordinates": [
-      -74.00350218,
-      40.72711527
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010721",
-    "coordinates": [
-      -74.00119407,
-      40.73188717
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010722",
-    "coordinates": [
-      -74.00523226,
-      40.72780341
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010726",
-    "coordinates": [
-      -73.99663087,
-      40.71903975
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010733",
-    "coordinates": [
-      -74.00540707,
-      40.72728365
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010737",
-    "coordinates": [
-      -74.00023841,
-      40.73288433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010741",
-    "coordinates": [
-      -73.9742489,
-      40.78382538
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010745",
-    "coordinates": [
-      -73.95536175,
-      40.76837393
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010750",
-    "coordinates": [
-      -74.00662855,
-      40.73025769
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010754",
-    "coordinates": [
-      -73.96782908,
-      40.75617415
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010755",
-    "coordinates": [
-      -73.97789516,
-      40.74223411
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010761",
-    "coordinates": [
-      -73.97976183,
-      40.73925317
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010764",
-    "coordinates": [
-      -73.99286971,
-      40.76338512
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010766",
-    "coordinates": [
-      -73.95968089,
-      40.77945381
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010784",
-    "coordinates": [
-      -73.96108153,
-      40.80149765
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010785",
-    "coordinates": [
-      -73.98703948,
-      40.72500355
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010786",
-    "coordinates": [
-      -73.96700524,
-      40.79340209
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010787",
-    "coordinates": [
-      -73.96166314,
-      40.76035998
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010788",
-    "coordinates": [
-      -73.96153957,
-      40.77691823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010790",
-    "coordinates": [
-      -73.96660446,
-      40.77051657
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010792",
-    "coordinates": [
-      -73.969308,
-      40.766736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010795",
-    "coordinates": [
-      -73.97188144,
-      40.78707884
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010797",
-    "coordinates": [
-      -73.97148731,
-      40.79270287
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010798",
-    "coordinates": [
-      -73.97844368,
-      40.77737709
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010802",
-    "coordinates": [
-      -73.989421,
-      40.721773
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010803",
-    "coordinates": [
-      -73.9832813,
-      40.72996268
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010805",
-    "coordinates": [
-      -73.970303,
-      40.764821
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010807",
-    "coordinates": [
-      -73.98641999,
-      40.74275953
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010808",
-    "coordinates": [
-      -74.0065562,
-      40.72056775
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010811",
-    "coordinates": [
-      -73.99326129,
-      40.74208082
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010812",
-    "coordinates": [
-      -73.98538074,
-      40.74232206
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010823",
-    "coordinates": [
-      -73.96672853,
-      40.75254917
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010826",
-    "coordinates": [
-      -73.96964871,
-      40.7536606
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010831",
-    "coordinates": [
-      -73.99149319,
-      40.76527687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010832",
-    "coordinates": [
-      -73.97619,
-      40.744154
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010833",
-    "coordinates": [
-      -73.99036533,
-      40.75153962
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010843",
-    "coordinates": [
-      -74.00641536,
-      40.73230778
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010844",
-    "coordinates": [
-      -74.00567121,
-      40.73827778
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010846",
-    "coordinates": [
-      -73.99820283,
-      40.76065999
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010852",
-    "coordinates": [
-      -73.9617454,
-      40.80059158
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010853",
-    "coordinates": [
-      -73.97913747,
-      40.78186119
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010857",
-    "coordinates": [
-      -73.99915159,
-      40.73439251
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010860",
-    "coordinates": [
-      -73.96381797,
-      40.75687875
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010861",
-    "coordinates": [
-      -73.96321332,
-      40.75770122
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010862",
-    "coordinates": [
-      -73.96359345,
-      40.75760431
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010870",
-    "coordinates": [
-      -74.00528546,
-      40.73879783
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010871",
-    "coordinates": [
-      -74.00640751,
-      40.73159252
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010872",
-    "coordinates": [
-      -73.98947427,
-      40.71950376
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010874",
-    "coordinates": [
-      -73.97205515,
-      40.78633453
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010882",
-    "coordinates": [
-      -73.96676342,
-      40.76974939
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010890",
-    "coordinates": [
-      -73.92295481,
-      40.81675132
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010896",
-    "coordinates": [
-      -73.9851189882664,
-      40.7276498658094
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010897",
-    "coordinates": [
-      -73.94624056,
-      40.8007812
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010900",
-    "coordinates": [
-      -73.99715554,
-      40.73653988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010914",
-    "coordinates": [
-      -73.93145198,
-      40.85225684
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010917",
-    "coordinates": [
-      -73.93536211,
-      40.84727016
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010919",
-    "coordinates": [
-      -73.96094657,
-      40.77760614
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010930",
-    "coordinates": [
-      -73.93725917,
-      40.84468912
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010933",
-    "coordinates": [
-      -73.96785533,
-      40.80298423
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010934",
-    "coordinates": [
-      -73.97197865,
-      40.7920348
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010942",
-    "coordinates": [
-      -73.948844,
-      40.823361
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010946",
-    "coordinates": [
-      -73.942682,
-      40.703654
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010956",
-    "coordinates": [
-      -73.94188652,
-      40.83274898
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010975",
-    "coordinates": [
-      -73.94925939,
-      40.82266347
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010979",
-    "coordinates": [
-      -73.92421781,
-      40.76150726
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010981",
-    "coordinates": [
-      -73.92211147,
-      40.76730678
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010982",
-    "coordinates": [
-      -73.96194569,
-      40.80069
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010990",
-    "coordinates": [
-      -73.98452873,
-      40.74575598
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010991",
-    "coordinates": [
-      -74.00813878,
-      40.72311759
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010992",
-    "coordinates": [
-      -74.00797977,
-      40.72287042
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010993",
-    "coordinates": [
-      -73.88970545,
-      40.74696638
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-010997",
-    "coordinates": [
-      -73.93565287,
-      40.84687477
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-010999",
-    "coordinates": [
-      -73.8478444,
-      40.69469686
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011000",
-    "coordinates": [
-      -73.99328247,
-      40.73663894
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011001",
-    "coordinates": [
-      -73.98513107,
-      40.73192289
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011003",
-    "coordinates": [
-      -73.99336333,
-      40.74741879
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011005",
-    "coordinates": [
-      -73.99915027,
-      40.73910655
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011006",
-    "coordinates": [
-      -73.99938138,
-      40.7391558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011008",
-    "coordinates": [
-      -73.99147237,
-      40.74493317
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011014",
-    "coordinates": [
-      -73.98229109,
-      40.73616484
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011029",
-    "coordinates": [
-      -73.91700042,
-      40.80737752
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011033",
-    "coordinates": [
-      -73.90196472,
-      40.86176218
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011039",
-    "coordinates": [
-      -73.8846895,
-      40.74748994
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011040",
-    "coordinates": [
-      -73.93727923,
-      40.82900248
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-011042",
-    "coordinates": [
-      -73.91849412,
-      40.75881765
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011048",
-    "coordinates": [
-      -73.96800953,
-      40.79237863
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011059",
-    "coordinates": [
-      -73.87816548,
-      40.74831104
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011068",
-    "coordinates": [
-      -73.98284709,
-      40.73076722
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011071",
-    "coordinates": [
-      -73.99300348,
-      40.74282792
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011073",
-    "coordinates": [
-      -73.94141973,
-      40.74766699
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011075",
-    "coordinates": [
-      -73.97946572,
-      40.73964666
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011080",
-    "coordinates": [
-      -73.98684237,
-      40.72529099
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011082",
-    "coordinates": [
-      -74.00444413,
-      40.74241855
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-011086",
-    "coordinates": [
-      -73.8888199,
-      40.74705911
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011088",
-    "coordinates": [
-      -73.96632817,
-      40.80439875
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011092",
-    "coordinates": [
-      -73.89214477,
-      40.74671112
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011094",
-    "coordinates": [
-      -73.95646462,
-      40.76695173
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011095",
-    "coordinates": [
-      -73.9928116,
-      40.7430973
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011098",
-    "coordinates": [
-      -73.94192414,
-      40.81802907
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011100",
-    "coordinates": [
-      -73.93583333,
-      40.84662333
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011103",
-    "coordinates": [
-      -73.88464352,
-      40.74762687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011104",
-    "coordinates": [
-      -73.99439314,
-      40.74051298
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011105",
-    "coordinates": [
-      -73.9939631,
-      40.74151493
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011106",
-    "coordinates": [
-      -73.99320916,
-      40.74254842
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011109",
-    "coordinates": [
-      -73.98397945,
-      40.72921987
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011110",
-    "coordinates": [
-      -73.98822418,
-      40.72380705
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011111",
-    "coordinates": [
-      -73.97141311,
-      40.78769783
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011115",
-    "coordinates": [
-      -73.87062416,
-      40.7491117
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011116",
-    "coordinates": [
-      -73.87146338,
-      40.74887831
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011120",
-    "coordinates": [
-      -73.92071953,
-      40.75312177
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011127",
-    "coordinates": [
-      -73.97059306,
-      40.75183416
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011130",
-    "coordinates": [
-      -73.99158984,
-      40.76478628
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011133",
-    "coordinates": [
-      -73.99799948,
-      40.74068566
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011138",
-    "coordinates": [
-      -73.9813679,
-      40.737088
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011149",
-    "coordinates": [
-      -73.938202,
-      40.82312447
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011150",
-    "coordinates": [
-      -73.87420307,
-      40.74859468
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011151",
-    "coordinates": [
-      -73.98115859,
-      40.73737306
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011156",
-    "coordinates": [
-      -73.98233804,
-      40.77623753
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011158",
-    "coordinates": [
-      -73.98254791,
-      40.73160198
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011159",
-    "coordinates": [
-      -73.95600349,
-      40.8033996
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011172",
-    "coordinates": [
-      -73.888492,
-      40.74722343
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011173",
-    "coordinates": [
-      -73.87951058,
-      40.74816825
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011177",
-    "coordinates": [
-      -73.9466648,
-      40.82670709
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011178",
-    "coordinates": [
-      -73.98186157,
-      40.73675561
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011179",
-    "coordinates": [
-      -73.97382819,
-      40.74739525
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011180",
-    "coordinates": [
-      -73.97360371,
-      40.74812083
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011182",
-    "coordinates": [
-      -73.95329055,
-      40.82285389
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011183",
-    "coordinates": [
-      -73.96817662,
-      40.79179421
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-011189",
-    "coordinates": [
-      -73.97089386,
-      40.79316136
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011194",
-    "coordinates": [
-      -73.89121486,
-      40.74679775
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011198",
-    "coordinates": [
-      -73.88227031,
-      40.74774238
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011200",
-    "coordinates": [
-      -73.88138742,
-      40.74797068
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011205",
-    "coordinates": [
-      -73.8729333,
-      40.7488692
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011207",
-    "coordinates": [
-      -73.87439289,
-      40.74870842
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011208",
-    "coordinates": [
-      -73.92905463,
-      40.75227852
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011214",
-    "coordinates": [
-      -73.97189334,
-      40.75045756
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011227",
-    "coordinates": [
-      -73.94207451,
-      40.81782145
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011231",
-    "coordinates": [
-      -73.99026177,
-      40.7664369
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011251",
-    "coordinates": [
-      -73.8820337,
-      40.74799093
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011252",
-    "coordinates": [
-      -73.8857513,
-      40.74760297
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011258",
-    "coordinates": [
-      -73.88092373,
-      40.74801962
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011259",
-    "coordinates": [
-      -73.88761509,
-      40.74741228
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011268",
-    "coordinates": [
-      -73.90745354,
-      40.75313917
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011271",
-    "coordinates": [
-      -73.908266,
-      40.851329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011291",
-    "coordinates": [
-      -73.9308176,
-      40.85312181
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011295",
-    "coordinates": [
-      -73.940075,
-      40.835729
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011299",
-    "coordinates": [
-      -73.935456,
-      40.846771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011303",
-    "coordinates": [
-      -73.9340696,
-      40.84867304
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011315",
-    "coordinates": [
-      -73.93810732,
-      40.79636046
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011320",
-    "coordinates": [
-      -73.93287,
-      40.850683
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011337",
-    "coordinates": [
-      -73.94496616,
-      40.80014153
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011338",
-    "coordinates": [
-      -73.93810707,
-      40.80383351
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011358",
-    "coordinates": [
-      -73.945436,
-      40.834974
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011370",
-    "coordinates": [
-      -73.93224896,
-      40.8511646
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011373",
-    "coordinates": [
-      -73.85118474,
-      40.69396285
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011377",
-    "coordinates": [
-      -74.00387699,
-      40.73290856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011378",
-    "coordinates": [
-      -73.93776628,
-      40.79682481
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011379",
-    "coordinates": [
-      -73.93470439,
-      40.80140456
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011383",
-    "coordinates": [
-      -73.90003051,
-      40.84909302
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011397",
-    "coordinates": [
-      -73.91402994,
-      40.82364629
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011415",
-    "coordinates": [
-      -73.912336,
-      40.755764
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011417",
-    "coordinates": [
-      -73.919649,
-      40.759199
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011423",
-    "coordinates": [
-      -74.00654892,
-      40.65574578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011425",
-    "coordinates": [
-      -73.91366803,
-      40.81948845
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011428",
-    "coordinates": [
-      -73.86643426,
-      40.75744562
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011438",
-    "coordinates": [
-      -73.94509159,
-      40.83328532
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011446",
-    "coordinates": [
-      -73.91254129,
-      40.76266328
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011461",
-    "coordinates": [
-      -73.91424246,
-      40.81886036
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011469",
-    "coordinates": [
-      -73.92127596,
-      40.76676629
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011473",
-    "coordinates": [
-      -73.95676156,
-      40.80236833
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011474",
-    "coordinates": [
-      -73.95648813,
-      40.80302425
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011495",
-    "coordinates": [
-      -73.93133833,
-      40.85241173
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011500",
-    "coordinates": [
-      -73.90899141,
-      40.81312832
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011501",
-    "coordinates": [
-      -73.90897566,
-      40.85187831
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011510",
-    "coordinates": [
-      -73.942563,
-      40.702936
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011512",
-    "coordinates": [
-      -73.942287,
-      40.702247
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011536",
-    "coordinates": [
-      -73.92939864,
-      40.75418823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011542",
-    "coordinates": [
-      -73.89219433,
-      40.84618976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011544",
-    "coordinates": [
-      -73.94791958,
-      40.81444736
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-011566",
-    "coordinates": [
-      -73.98380229,
-      40.73195957
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011583",
-    "coordinates": [
-      -73.893343,
-      40.860027
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011588",
-    "coordinates": [
-      -73.90750182,
-      40.85393036
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011595",
-    "coordinates": [
-      -73.949935,
-      40.676752
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011599",
-    "coordinates": [
-      -73.91093862,
-      40.76191296
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011604",
-    "coordinates": [
-      -73.949916,
-      40.676976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011621",
-    "coordinates": [
-      -73.89339767,
-      40.84652245
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011622",
-    "coordinates": [
-      -73.97393282,
-      40.68213254
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011626",
-    "coordinates": [
-      -73.932187,
-      40.65159
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011635",
-    "coordinates": [
-      -73.95091335,
-      40.66620283
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011660",
-    "coordinates": [
-      -73.912327,
-      40.821437
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011663",
-    "coordinates": [
-      -73.89644355,
-      40.86117438
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011667",
-    "coordinates": [
-      -73.907548,
-      40.862685
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011704",
-    "coordinates": [
-      -73.95757439,
-      40.64287503
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011709",
-    "coordinates": [
-      -73.91949122,
-      40.81357503
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011729",
-    "coordinates": [
-      -73.950008,
-      40.675965
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011738",
-    "coordinates": [
-      -73.92992035,
-      40.85435846
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011757",
-    "coordinates": [
-      -73.89822056,
-      40.84692617
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011760",
-    "coordinates": [
-      -73.83960659,
-      40.6956028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011761",
-    "coordinates": [
-      -73.950627,
-      40.670115
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011768",
-    "coordinates": [
-      -73.950397,
-      40.670147
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011770",
-    "coordinates": [
-      -73.92793528,
-      40.7630995
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011778",
-    "coordinates": [
-      -73.95296626,
-      40.74549641
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011789",
-    "coordinates": [
-      -73.91283823,
-      40.82010249
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011802",
-    "coordinates": [
-      -74.00828534,
-      40.65039017
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011809",
-    "coordinates": [
-      -73.98165945,
-      40.73087757
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011822",
-    "coordinates": [
-      -73.93684737,
-      40.84475573
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-011824",
-    "coordinates": [
-      -73.94252463,
-      40.81738064
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011851",
-    "coordinates": [
-      -73.89994835,
-      40.84740591
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011861",
-    "coordinates": [
-      -73.90938798,
-      40.85384203
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011874",
-    "coordinates": [
-      -73.91147,
-      40.84873
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011876",
-    "coordinates": [
-      -73.91430035,
-      40.81855965
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011877",
-    "coordinates": [
-      -73.913388,
-      40.819568
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011905",
-    "coordinates": [
-      -73.845595,
-      40.695205
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011906",
-    "coordinates": [
-      -73.858948,
-      40.692466
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011912",
-    "coordinates": [
-      -73.914259,
-      40.763621
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011971",
-    "coordinates": [
-      -73.944659,
-      40.818897
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011980",
-    "coordinates": [
-      -73.94842204,
-      40.82966242
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011982",
-    "coordinates": [
-      -73.98597197,
-      40.74349317
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-011998",
-    "coordinates": [
-      -73.95384878,
-      40.81120483
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012012",
-    "coordinates": [
-      -73.954886,
-      40.7334
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012026",
-    "coordinates": [
-      -73.939589,
-      40.835586
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012038",
-    "coordinates": [
-      -73.94594832,
-      40.71444574
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012042",
-    "coordinates": [
-      -73.93177297,
-      40.85183107
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012080",
-    "coordinates": [
-      -73.91648285,
-      40.81667907
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012113",
-    "coordinates": [
-      -73.96127853,
-      40.80124724
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012117",
-    "coordinates": [
-      -73.944206,
-      40.713913
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012120",
-    "coordinates": [
-      -73.901951,
-      40.846169
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012130",
-    "coordinates": [
-      -73.91962478,
-      40.813367
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012132",
-    "coordinates": [
-      -73.92143417,
-      40.81089649
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012163",
-    "coordinates": [
-      -73.946762,
-      40.80007
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012172",
-    "coordinates": [
-      -73.91646687,
-      40.81216272
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012181",
-    "coordinates": [
-      -73.993513,
-      40.736806
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012188",
-    "coordinates": [
-      -73.98188075,
-      40.7622099
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012192",
-    "coordinates": [
-      -74.00560969,
-      40.71772575
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012216",
-    "coordinates": [
-      -73.99208429,
-      40.7437055
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012224",
-    "coordinates": [
-      -73.977306,
-      40.750237
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012227",
-    "coordinates": [
-      -73.98344153,
-      40.76686129
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012235",
-    "coordinates": [
-      -73.99764592,
-      40.71665239
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012236",
-    "coordinates": [
-      -73.9525944,
-      40.77814082
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012242",
-    "coordinates": [
-      -74.00677065,
-      40.72301338
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012249",
-    "coordinates": [
-      -73.997578,
-      40.716869
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012250",
-    "coordinates": [
-      -74.00627426,
-      40.725666
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012255",
-    "coordinates": [
-      -73.9877384,
-      40.73809688
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012278",
-    "coordinates": [
-      -73.98106107,
-      40.74705459
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012291",
-    "coordinates": [
-      -73.9902101,
-      40.76668319
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012297",
-    "coordinates": [
-      -73.96139743,
-      40.76094634
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012298",
-    "coordinates": [
-      -73.96321301,
-      40.7619766
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012299",
-    "coordinates": [
-      -73.9565366,
-      40.76728194
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012317",
-    "coordinates": [
-      -73.98908323,
-      40.72048554
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012325",
-    "coordinates": [
-      -73.98593572,
-      40.74671976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012326",
-    "coordinates": [
-      -73.96335362,
-      40.76214654
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012328",
-    "coordinates": [
-      -73.966995,
-      40.763419
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012330",
-    "coordinates": [
-      -73.98948974,
-      40.76766312
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012333",
-    "coordinates": [
-      -73.970823,
-      40.764097
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012359",
-    "coordinates": [
-      -73.96459519,
-      40.75581174
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012360",
-    "coordinates": [
-      -73.95313791,
-      40.77152635
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012363",
-    "coordinates": [
-      -73.96518956,
-      40.75499065
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012365",
-    "coordinates": [
-      -73.96543425,
-      40.7550807
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012369",
-    "coordinates": [
-      -73.9786294,
-      40.77724121
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012370",
-    "coordinates": [
-      -73.967597,
-      40.768649
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012372",
-    "coordinates": [
-      -73.99799012,
-      40.73598356
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012375",
-    "coordinates": [
-      -73.95920163,
-      40.76321777
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012376",
-    "coordinates": [
-      -73.96997867,
-      40.76621551
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012396",
-    "coordinates": [
-      -73.98430909,
-      40.72944908
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012405",
-    "coordinates": [
-      -73.97825829,
-      40.7574068
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012406",
-    "coordinates": [
-      -73.96372269,
-      40.77449753
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012424",
-    "coordinates": [
-      -73.98610433,
-      40.72630382
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012438",
-    "coordinates": [
-      -73.97730732,
-      40.74303942
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012443",
-    "coordinates": [
-      -73.93292644,
-      40.8502485
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012452",
-    "coordinates": [
-      -73.97785338,
-      40.77888904
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012454",
-    "coordinates": [
-      -73.9723114,
-      40.78665384
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012457",
-    "coordinates": [
-      -73.968865,
-      40.767364
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012458",
-    "coordinates": [
-      -73.978561,
-      40.740894
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012462",
-    "coordinates": [
-      -73.97568365,
-      40.76111775
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012472",
-    "coordinates": [
-      -73.98965898,
-      40.76778999
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012482",
-    "coordinates": [
-      -73.96346015,
-      40.77428147
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012484",
-    "coordinates": [
-      -73.96011567,
-      40.77879465
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012486",
-    "coordinates": [
-      -73.96390551,
-      40.75717377
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012502",
-    "coordinates": [
-      -73.96891544,
-      40.79078578
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012503",
-    "coordinates": [
-      -73.96418067,
-      40.76104904
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012510",
-    "coordinates": [
-      -73.98107921,
-      40.77496988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012513",
-    "coordinates": [
-      -73.968364,
-      40.768093
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012517",
-    "coordinates": [
-      -73.98236687,
-      40.77544328
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012528",
-    "coordinates": [
-      -73.9827647,
-      40.73152105
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012532",
-    "coordinates": [
-      -73.93976734,
-      40.82596687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012535",
-    "coordinates": [
-      -73.98096599,
-      40.78094218
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012539",
-    "coordinates": [
-      -73.94544961,
-      40.83418925
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012540",
-    "coordinates": [
-      -73.94577543,
-      40.82792507
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012542",
-    "coordinates": [
-      -73.94622593,
-      40.82730494
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012543",
-    "coordinates": [
-      -73.94420042,
-      40.82973306
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012544",
-    "coordinates": [
-      -73.94929876,
-      40.82831959
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012545",
-    "coordinates": [
-      -73.97002379,
-      40.78962178
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012553",
-    "coordinates": [
-      -73.95903881,
-      40.76343296
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012560",
-    "coordinates": [
-      -74.00808439,
-      40.72340371
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012563",
-    "coordinates": [
-      -73.98503716,
-      40.74762726
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012570",
-    "coordinates": [
-      -73.99679984,
-      40.74269967
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012572",
-    "coordinates": [
-      -73.97684323,
-      40.74365854
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012573",
-    "coordinates": [
-      -73.97904816,
-      40.74023291
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012574",
-    "coordinates": [
-      -73.9792518,
-      40.74036856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012575",
-    "coordinates": [
-      -73.97907885,
-      40.74061156
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012579",
-    "coordinates": [
-      -73.99024141,
-      40.74661929
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012586",
-    "coordinates": [
-      -73.92362684,
-      40.75577655
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012591",
-    "coordinates": [
-      -73.9702839,
-      40.78926318
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012596",
-    "coordinates": [
-      -73.98993307,
-      40.76704736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012609",
-    "coordinates": [
-      -73.98754894,
-      40.74417468
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012611",
-    "coordinates": [
-      -73.88792592,
-      40.74715289
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012614",
-    "coordinates": [
-      -73.98813678,
-      40.75459325
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012618",
-    "coordinates": [
-      -73.96062004,
-      40.76126735
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012620",
-    "coordinates": [
-      -73.99188287,
-      40.7439707
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012621",
-    "coordinates": [
-      -73.9682952,
-      40.80009304
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012622",
-    "coordinates": [
-      -73.97769449,
-      40.74206862
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012623",
-    "coordinates": [
-      -73.97059943,
-      40.79599586
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012631",
-    "coordinates": [
-      -73.98313231,
-      40.74440678
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012636",
-    "coordinates": [
-      -74.00358788,
-      40.74359974
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012639",
-    "coordinates": [
-      -73.97998543,
-      40.73934123
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012640",
-    "coordinates": [
-      -73.9838785,
-      40.74339468
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012642",
-    "coordinates": [
-      -73.99181959,
-      40.76445589
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012645",
-    "coordinates": [
-      -73.98904337,
-      40.76826158
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012646",
-    "coordinates": [
-      -73.99131194,
-      40.76515921
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012647",
-    "coordinates": [
-      -73.99196653,
-      40.76462448
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012649",
-    "coordinates": [
-      -73.98160829,
-      40.7367472
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012661",
-    "coordinates": [
-      -73.99077541,
-      40.74549407
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012665",
-    "coordinates": [
-      -73.99629565,
-      40.7383024
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012666",
-    "coordinates": [
-      -73.95025609,
-      40.80662994
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012671",
-    "coordinates": [
-      -73.95964853,
-      40.76259531
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012673",
-    "coordinates": [
-      -73.93536309,
-      40.84751332
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012676",
-    "coordinates": [
-      -73.97893462,
-      40.74122503
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012677",
-    "coordinates": [
-      -73.98272283,
-      40.74498361
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012679",
-    "coordinates": [
-      -73.97106076,
-      40.75118754
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012682",
-    "coordinates": [
-      -73.99119855,
-      40.73916604
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012685",
-    "coordinates": [
-      -73.99336769,
-      40.76233629
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012689",
-    "coordinates": [
-      -73.99085201,
-      40.76578851
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012691",
-    "coordinates": [
-      -73.99105738,
-      40.7658753
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012694",
-    "coordinates": [
-      -73.99456317,
-      40.74526758
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012695",
-    "coordinates": [
-      -73.98538547,
-      40.74132322
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012709",
-    "coordinates": [
-      -73.99282602,
-      40.73727988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012714",
-    "coordinates": [
-      -73.98039603,
-      40.73838376
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012715",
-    "coordinates": [
-      -73.96540561,
-      40.75469528
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012722",
-    "coordinates": [
-      -73.98469437,
-      40.73251879
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012727",
-    "coordinates": [
-      -73.99011216,
-      40.75152164
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012730",
-    "coordinates": [
-      -73.98924679,
-      40.7306716
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012735",
-    "coordinates": [
-      -73.98276825,
-      40.74533995
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012758",
-    "coordinates": [
-      -73.97048243,
-      40.78898616
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012761",
-    "coordinates": [
-      -73.93836455,
-      40.82290225
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012766",
-    "coordinates": [
-      -73.97715884,
-      40.74685005
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012768",
-    "coordinates": [
-      -73.934241,
-      40.84844385
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012769",
-    "coordinates": [
-      -73.96915525,
-      40.79044448
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012770",
-    "coordinates": [
-      -73.95740873,
-      40.76566545
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012772",
-    "coordinates": [
-      -73.98061045,
-      40.7385025
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012780",
-    "coordinates": [
-      -73.97954419,
-      40.73996264
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012782",
-    "coordinates": [
-      -73.9703352,
-      40.78883163
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012786",
-    "coordinates": [
-      -73.87577475,
-      40.74855095
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012787",
-    "coordinates": [
-      -73.87938648,
-      40.74804918
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012788",
-    "coordinates": [
-      -73.96311539,
-      40.79871675
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012790",
-    "coordinates": [
-      -73.96597025,
-      40.75375106
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012792",
-    "coordinates": [
-      -73.97452006,
-      40.74686754
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012796",
-    "coordinates": [
-      -73.99050599,
-      40.7462509
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012802",
-    "coordinates": [
-      -73.99683036,
-      40.74230081
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012804",
-    "coordinates": [
-      -73.95894778,
-      40.76411658
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-012805",
-    "coordinates": [
-      -73.96208669,
-      40.76389092
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012809",
-    "coordinates": [
-      -73.98705217,
-      40.73946433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012814",
-    "coordinates": [
-      -73.97007535,
-      40.78918247
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012818",
-    "coordinates": [
-      -73.9982041,
-      40.74077246
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012822",
-    "coordinates": [
-      -73.87181741,
-      40.74908967
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012825",
-    "coordinates": [
-      -73.94987,
-      40.652771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012850",
-    "coordinates": [
-      -73.98733637,
-      40.724614
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012853",
-    "coordinates": [
-      -73.98382369,
-      40.72943593
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012858",
-    "coordinates": [
-      -73.98449219,
-      40.74598598
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012859",
-    "coordinates": [
-      -73.9658397,
-      40.75877707
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012863",
-    "coordinates": [
-      -73.93352882,
-      40.84942275
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012865",
-    "coordinates": [
-      -73.96550379,
-      40.75923366
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012881",
-    "coordinates": [
-      -73.908662,
-      40.853881
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012887",
-    "coordinates": [
-      -73.92851391,
-      40.76355288
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012888",
-    "coordinates": [
-      -73.926262,
-      40.762464
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012889",
-    "coordinates": [
-      -73.92387,
-      40.761341
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012917",
-    "coordinates": [
-      -73.88409786,
-      40.74754337
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012921",
-    "coordinates": [
-      -73.91671907,
-      40.8166923
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012923",
-    "coordinates": [
-      -73.95569057,
-      40.76777013
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012925",
-    "coordinates": [
-      -73.91899505,
-      40.74221127
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012938",
-    "coordinates": [
-      -73.94338965,
-      40.70892202
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012975",
-    "coordinates": [
-      -73.91873252,
-      40.74218025
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-012986",
-    "coordinates": [
-      -73.9870681131993,
-      40.6875936081062
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013014",
-    "coordinates": [
-      -73.90076644,
-      40.8475737
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013018",
-    "coordinates": [
-      -73.91293263,
-      40.80470552
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013019",
-    "coordinates": [
-      -73.9176574,
-      40.80681954
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013023",
-    "coordinates": [
-      -73.95077465,
-      40.66382689
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013042",
-    "coordinates": [
-      -73.90824221,
-      40.81599771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013063",
-    "coordinates": [
-      -73.94328498,
-      40.82079611
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013068",
-    "coordinates": [
-      -73.98441867,
-      40.72862184
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013082",
-    "coordinates": [
-      -73.913259,
-      40.763
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013089",
-    "coordinates": [
-      -73.99124562,
-      40.66355007
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013093",
-    "coordinates": [
-      -73.96283585,
-      40.64185835
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013095",
-    "coordinates": [
-      -73.950234,
-      40.674266
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013104",
-    "coordinates": [
-      -73.939286,
-      40.821828
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013111",
-    "coordinates": [
-      -73.945253,
-      40.807779
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013117",
-    "coordinates": [
-      -73.98029,
-      40.676409
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013122",
-    "coordinates": [
-      -73.9426993,
-      40.82159551
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013129",
-    "coordinates": [
-      -73.942876,
-      40.837241
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013157",
-    "coordinates": [
-      -73.9492591,
-      40.80194888
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013160",
-    "coordinates": [
-      -73.95698009,
-      40.80234988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013161",
-    "coordinates": [
-      -73.941152,
-      40.818505
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013162",
-    "coordinates": [
-      -73.94264858,
-      40.81644556
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013167",
-    "coordinates": [
-      -73.96144841,
-      40.80100105
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013169",
-    "coordinates": [
-      -73.94377622,
-      40.8201217
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013170",
-    "coordinates": [
-      -73.94750336,
-      40.81537577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013171",
-    "coordinates": [
-      -73.950658,
-      40.81069
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013172",
-    "coordinates": [
-      -73.950557,
-      40.805615
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013185",
-    "coordinates": [
-      -73.989183,
-      40.736141
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013196",
-    "coordinates": [
-      -73.89607854,
-      40.86205098
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013203",
-    "coordinates": [
-      -73.92045929,
-      40.76638612
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013212",
-    "coordinates": [
-      -73.950078,
-      40.673527
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013218",
-    "coordinates": [
-      -73.91825809,
-      40.82560474
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013228",
-    "coordinates": [
-      -73.94859133,
-      40.80918643
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013234",
-    "coordinates": [
-      -73.94812464,
-      40.80879309
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013237",
-    "coordinates": [
-      -73.911439,
-      40.854764
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013242",
-    "coordinates": [
-      -73.919637,
-      40.816692
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013275",
-    "coordinates": [
-      -73.9905922,
-      40.75122432
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013290",
-    "coordinates": [
-      -74.00648828,
-      40.72098349
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-013299",
-    "coordinates": [
-      -73.86199361,
-      40.69210611
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013313",
-    "coordinates": [
-      -73.91620844,
-      40.8171412
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013324",
-    "coordinates": [
-      -73.89839588,
-      40.86215226
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013345",
-    "coordinates": [
-      -73.94601241,
-      40.81705699
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013346",
-    "coordinates": [
-      -73.94654809,
-      40.81668892
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013347",
-    "coordinates": [
-      -73.94655805,
-      40.81629802
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013348",
-    "coordinates": [
-      -73.941723,
-      40.822924
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013349",
-    "coordinates": [
-      -73.9486889,
-      40.80902187
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013350",
-    "coordinates": [
-      -73.95426274,
-      40.80579247
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013353",
-    "coordinates": [
-      -73.95209309,
-      40.80873329
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013356",
-    "coordinates": [
-      -73.95015967,
-      40.81136226
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013357",
-    "coordinates": [
-      -73.95071065,
-      40.81098881
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013359",
-    "coordinates": [
-      -73.94583035,
-      40.80781772
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013360",
-    "coordinates": [
-      -73.948011,
-      40.808939
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013361",
-    "coordinates": [
-      -73.94223468,
-      40.82221486
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013362",
-    "coordinates": [
-      -73.94030397,
-      40.82040617
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013368",
-    "coordinates": [
-      -73.943064,
-      40.79357
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013369",
-    "coordinates": [
-      -73.941542,
-      40.798488
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013370",
-    "coordinates": [
-      -73.94142153,
-      40.79864627
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013381",
-    "coordinates": [
-      -73.952053,
-      40.811325
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013384",
-    "coordinates": [
-      -73.93218652,
-      40.85162018
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013398",
-    "coordinates": [
-      -73.93451006,
-      40.84808255
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-013458",
-    "coordinates": [
-      -73.95072664,
-      40.6607318
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013459",
-    "coordinates": [
-      -73.95040697,
-      40.65773965
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013464",
-    "coordinates": [
-      -73.9817194,
-      40.68721034
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013485",
-    "coordinates": [
-      -73.95918257,
-      40.70877985
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013489",
-    "coordinates": [
-      -73.94979845,
-      40.67826808
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013497",
-    "coordinates": [
-      -73.949966,
-      40.65532
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013508",
-    "coordinates": [
-      -73.9159581,
-      40.76427257
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013510",
-    "coordinates": [
-      -73.88415453,
-      40.74982932
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013521",
-    "coordinates": [
-      -73.8446443,
-      40.72024516
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013522",
-    "coordinates": [
-      -73.844787,
-      40.720017
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013525",
-    "coordinates": [
-      -73.91667316,
-      40.76970698
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013526",
-    "coordinates": [
-      -73.912837,
-      40.76909552
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013527",
-    "coordinates": [
-      -73.93142777,
-      40.76516019
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013542",
-    "coordinates": [
-      -73.86085811,
-      40.69245106
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013543",
-    "coordinates": [
-      -73.88106477,
-      40.74199055
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013545",
-    "coordinates": [
-      -73.919926,
-      40.75949
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013546",
-    "coordinates": [
-      -73.922879,
-      40.760713
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013594",
-    "coordinates": [
-      -73.91505124,
-      40.76368606
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013596",
-    "coordinates": [
-      -73.87652268,
-      40.74834975
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013597",
-    "coordinates": [
-      -73.88366475,
-      40.74772878
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013607",
-    "coordinates": [
-      -73.85077696,
-      40.72249917
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013612",
-    "coordinates": [
-      -73.84311,
-      40.695248
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013616",
-    "coordinates": [
-      -73.91968964,
-      40.74184571
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013622",
-    "coordinates": [
-      -73.88002682,
-      40.74798095
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013628",
-    "coordinates": [
-      -73.92505031,
-      40.76189688
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013629",
-    "coordinates": [
-      -73.91894987,
-      40.759169
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013670",
-    "coordinates": [
-      -73.98016085,
-      40.77535675
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013673",
-    "coordinates": [
-      -73.95806217,
-      40.76519297
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013674",
-    "coordinates": [
-      -73.95853038,
-      40.76394756
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013676",
-    "coordinates": [
-      -73.95757799,
-      40.76599549
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013681",
-    "coordinates": [
-      -73.95872117,
-      40.78071593
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013686",
-    "coordinates": [
-      -73.96622435,
-      40.77045871
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013690",
-    "coordinates": [
-      -73.97693216,
-      40.78014761
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013700",
-    "coordinates": [
-      -73.97518778,
-      40.75118164
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013709",
-    "coordinates": [
-      -73.97424149,
-      40.74725106
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013710",
-    "coordinates": [
-      -73.9734053,
-      40.74796623
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013711",
-    "coordinates": [
-      -73.97836301,
-      40.74159316
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013712",
-    "coordinates": [
-      -73.98014812,
-      40.73913724
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013713",
-    "coordinates": [
-      -73.979693,
-      40.73976238
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013714",
-    "coordinates": [
-      -73.97932655,
-      40.73985154
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013718",
-    "coordinates": [
-      -73.98105517,
-      40.73805173
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013720",
-    "coordinates": [
-      -73.98482253,
-      40.732206
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013724",
-    "coordinates": [
-      -73.9755338,
-      40.74960493
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013727",
-    "coordinates": [
-      -73.970116,
-      40.752476
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013736",
-    "coordinates": [
-      -73.98250633,
-      40.74514234
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013738",
-    "coordinates": [
-      -73.98337004,
-      40.74389121
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013740",
-    "coordinates": [
-      -73.98198711,
-      40.74573985
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013747",
-    "coordinates": [
-      -73.98542849,
-      40.74396179
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013750",
-    "coordinates": [
-      -73.98409911,
-      40.7465113
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013751",
-    "coordinates": [
-      -73.98371405,
-      40.74646478
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013753",
-    "coordinates": [
-      -73.983698,
-      40.747144
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013755",
-    "coordinates": [
-      -73.98664796,
-      40.74257286
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013757",
-    "coordinates": [
-      -73.96665144,
-      40.75341389
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013759",
-    "coordinates": [
-      -73.96565023,
-      40.75437122
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013760",
-    "coordinates": [
-      -73.95999822,
-      40.76199324
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-013763",
-    "coordinates": [
-      -73.96291405,
-      40.7581134
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013769",
-    "coordinates": [
-      -73.96268514,
-      40.76307964
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013776",
-    "coordinates": [
-      -73.96331113,
-      40.76174825
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013777",
-    "coordinates": [
-      -73.96516242,
-      40.75914915
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013778",
-    "coordinates": [
-      -73.9691842,
-      40.75439185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013780",
-    "coordinates": [
-      -73.96315851,
-      40.76241687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013801",
-    "coordinates": [
-      -73.97543366,
-      40.75773384
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013805",
-    "coordinates": [
-      -73.98833004,
-      40.75431145
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013806",
-    "coordinates": [
-      -73.98832163,
-      40.75397801
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013808",
-    "coordinates": [
-      -73.99106942,
-      40.75127386
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013817",
-    "coordinates": [
-      -73.980768,
-      40.730496
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013832",
-    "coordinates": [
-      -73.98019325,
-      40.75495251
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013834",
-    "coordinates": [
-      -73.99028957,
-      40.74600486
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013840",
-    "coordinates": [
-      -73.99615313,
-      40.73810851
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013841",
-    "coordinates": [
-      -74.00581491,
-      40.71780497
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013842",
-    "coordinates": [
-      -73.99071175,
-      40.74598929
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013843",
-    "coordinates": [
-      -73.99605667,
-      40.73863995
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013844",
-    "coordinates": [
-      -73.9927995,
-      40.74272274
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013858",
-    "coordinates": [
-      -73.99058102,
-      40.71709475
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013872",
-    "coordinates": [
-      -73.99180123,
-      40.74915253
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013873",
-    "coordinates": [
-      -73.992745,
-      40.747904
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013880",
-    "coordinates": [
-      -73.9966041,
-      40.73788645
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013881",
-    "coordinates": [
-      -73.99364234,
-      40.76232841
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013883",
-    "coordinates": [
-      -73.98921452,
-      40.76840586
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013904",
-    "coordinates": [
-      -73.99250826,
-      40.74351013
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013905",
-    "coordinates": [
-      -73.98867303,
-      40.74877222
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013913",
-    "coordinates": [
-      -73.98277309,
-      40.7717802
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013920",
-    "coordinates": [
-      -73.97609914,
-      40.76047373
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013923",
-    "coordinates": [
-      -73.97792563,
-      40.75795791
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013928",
-    "coordinates": [
-      -74.00622249,
-      40.71693937
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013954",
-    "coordinates": [
-      -73.986712,
-      40.739409
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013956",
-    "coordinates": [
-      -73.99138693,
-      40.73239147
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013962",
-    "coordinates": [
-      -74.00238535,
-      40.7295577
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013965",
-    "coordinates": [
-      -73.989871,
-      40.735187
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013970",
-    "coordinates": [
-      -73.9851321,
-      40.73224694
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013971",
-    "coordinates": [
-      -73.98309797,
-      40.73083305
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013973",
-    "coordinates": [
-      -73.98617294,
-      40.7329605
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013974",
-    "coordinates": [
-      -73.98813578,
-      40.74083617
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013976",
-    "coordinates": [
-      -73.994986,
-      40.744815
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013990",
-    "coordinates": [
-      -73.995892,
-      40.744114
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013992",
-    "coordinates": [
-      -73.99616801,
-      40.74356421
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-013993",
-    "coordinates": [
-      -74.00690371,
-      40.74875784
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014004",
-    "coordinates": [
-      -74.00579536,
-      40.72492489
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014008",
-    "coordinates": [
-      -73.994537,
-      40.745448
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014013",
-    "coordinates": [
-      -73.985069,
-      40.744614
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014014",
-    "coordinates": [
-      -73.98324565,
-      40.73153857
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014015",
-    "coordinates": [
-      -73.982827,
-      40.73121904
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014021",
-    "coordinates": [
-      -73.91468375,
-      40.81846074
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014052",
-    "coordinates": [
-      -73.95035244,
-      40.67064687
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014063",
-    "coordinates": [
-      -73.84283995,
-      40.6952564
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014075",
-    "coordinates": [
-      -73.99079235,
-      40.74611567
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014096",
-    "coordinates": [
-      -73.96407038,
-      40.75694399
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014133_Old",
-    "coordinates": [
-      -73.91297466,
-      40.75607269
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014139",
-    "coordinates": [
-      -73.89344842,
-      40.74670669
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014173",
-    "coordinates": [
-      -73.9631832,
-      40.79947246
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014174",
-    "coordinates": [
-      -73.9930158102286,
-      40.758482405837
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014179",
-    "coordinates": [
-      -73.98618292,
-      40.74739113
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014181_Old",
-    "coordinates": [
-      -73.9738668,
-      40.78944465
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014184",
-    "coordinates": [
-      -73.97404944,
-      40.78409642
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014189",
-    "coordinates": [
-      -73.97905068,
-      40.77657343
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014190",
-    "coordinates": [
-      -73.99306771,
-      40.72018834
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014191",
-    "coordinates": [
-      -73.95875952,
-      40.7638554
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014205",
-    "coordinates": [
-      -73.95460936,
-      40.76950566
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014206",
-    "coordinates": [
-      -74.0067043,
-      40.748842
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014207",
-    "coordinates": [
-      -73.96189127,
-      40.80040455
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014212",
-    "coordinates": [
-      -73.9935926,
-      40.74150205
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014220",
-    "coordinates": [
-      -73.99167705,
-      40.74484704
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014226",
-    "coordinates": [
-      -73.99907941,
-      40.71716821
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014236",
-    "coordinates": [
-      -73.943527,
-      40.799528
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014238",
-    "coordinates": [
-      -73.95971503,
-      40.76292088
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014247",
-    "coordinates": [
-      -73.99404694,
-      40.68134564
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014248",
-    "coordinates": [
-      -73.92268748,
-      40.76743258
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014249",
-    "coordinates": [
-      -73.926808,
-      40.76272
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014256",
-    "coordinates": [
-      -74.00546559,
-      40.73835105
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014263",
-    "coordinates": [
-      -73.991198,
-      40.716355
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014272",
-    "coordinates": [
-      -73.92841499,
-      40.85642084
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014273",
-    "coordinates": [
-      -73.86326155,
-      40.69190229
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014293",
-    "coordinates": [
-      -74.00202234,
-      40.72433792
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014303",
-    "coordinates": [
-      -73.857547,
-      40.692672
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014316",
-    "coordinates": [
-      -73.991208,
-      40.734036
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014321",
-    "coordinates": [
-      -73.93082739,
-      40.85291726
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014333",
-    "coordinates": [
-      -73.866734,
-      40.69145
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014335",
-    "coordinates": [
-      -73.90139163,
-      40.84664641
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014352",
-    "coordinates": [
-      -73.88498743,
-      40.7474512
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014393",
-    "coordinates": [
-      -73.90991661,
-      40.81618821
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014398",
-    "coordinates": [
-      -73.9293896,
-      40.85487571
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014399",
-    "coordinates": [
-      -73.95679626,
-      40.80260688
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014405",
-    "coordinates": [
-      -73.89253173,
-      40.74667176
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014406",
-    "coordinates": [
-      -73.87871569,
-      40.74825267
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014407",
-    "coordinates": [
-      -73.8704887,
-      40.74897101
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014420",
-    "coordinates": [
-      -73.9885843,
-      40.73796976
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014430",
-    "coordinates": [
-      -73.86858881,
-      40.75748463
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014433",
-    "coordinates": [
-      -73.96483887,
-      40.77237316
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014437",
-    "coordinates": [
-      -74.00417706,
-      40.74788855
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014438",
-    "coordinates": [
-      -73.98610741,
-      40.73274736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014440",
-    "coordinates": [
-      -73.9942271,
-      40.69472554
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014444",
-    "coordinates": [
-      -73.94700174,
-      40.81569589
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014483",
-    "coordinates": [
-      -73.915574,
-      40.817446
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014485",
-    "coordinates": [
-      -73.8938944,
-      40.86234731
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014492",
-    "coordinates": [
-      -73.91582926,
-      40.817235
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014561",
-    "coordinates": [
-      -73.92154563,
-      40.7668938
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014595",
-    "coordinates": [
-      -73.918194,
-      40.840248
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014602",
-    "coordinates": [
-      -73.91988166,
-      40.76592997
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014604",
-    "coordinates": [
-      -73.89236832,
-      40.74660883
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014609",
-    "coordinates": [
-      -73.910931,
-      40.849486
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014610",
-    "coordinates": [
-      -73.980968,
-      40.737627
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014611",
-    "coordinates": [
-      -73.97797283,
-      40.74171074
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014613",
-    "coordinates": [
-      -73.9182259,
-      40.83490416
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014614",
-    "coordinates": [
-      -73.9715336,
-      40.75129568
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014618",
-    "coordinates": [
-      -73.95769383,
-      40.76511946
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014623",
-    "coordinates": [
-      -73.97882096,
-      40.74509981
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014625",
-    "coordinates": [
-      -73.97468574,
-      40.74665132
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014638",
-    "coordinates": [
-      -73.99352183,
-      40.74212565
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014639",
-    "coordinates": [
-      -73.969254,
-      40.795399
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014642",
-    "coordinates": [
-      -73.95213993,
-      40.80404696
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014643",
-    "coordinates": [
-      -73.95075428,
-      40.80595028
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014645",
-    "coordinates": [
-      -73.94055195,
-      40.81991621
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014647",
-    "coordinates": [
-      -73.94101785,
-      40.8192929
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-014648",
-    "coordinates": [
-      -73.942056,
-      40.817264
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014649",
-    "coordinates": [
-      -73.94284249,
-      40.81677995
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014650",
-    "coordinates": [
-      -73.944756,
-      40.814156
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014651",
-    "coordinates": [
-      -73.945458,
-      40.812611
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014655",
-    "coordinates": [
-      -73.95009459,
-      40.80624896
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014662",
-    "coordinates": [
-      -73.94244453,
-      40.8223078
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-014670",
-    "coordinates": [
-      -73.9351479,
-      40.8471969
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-015044",
-    "coordinates": [
-      -73.973409,
-      40.792132
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018037",
-    "coordinates": [
-      -73.87083775,
-      40.7333421
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018040",
-    "coordinates": [
-      -73.853138,
-      40.726495
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018041",
-    "coordinates": [
-      -73.853929,
-      40.726695
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018042",
-    "coordinates": [
-      -73.854789,
-      40.727095
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018043",
-    "coordinates": [
-      -73.85607116,
-      40.72748901
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018045",
-    "coordinates": [
-      -73.856848,
-      40.72785
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018046",
-    "coordinates": [
-      -73.85744565,
-      40.72806732
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018047",
-    "coordinates": [
-      -73.9925546,
-      40.69828038
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018057",
-    "coordinates": [
-      -73.98187215,
-      40.68803876
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018062",
-    "coordinates": [
-      -73.97332,
-      40.685787
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018064",
-    "coordinates": [
-      -73.97022462,
-      40.68454905
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018067",
-    "coordinates": [
-      -73.967093,
-      40.683591
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018068",
-    "coordinates": [
-      -73.96463345,
-      40.68307692
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018071",
-    "coordinates": [
-      -73.9616482,
-      40.68219957
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018080",
-    "coordinates": [
-      -73.958801,
-      40.668156
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018081",
-    "coordinates": [
-      -73.95956788,
-      40.65470433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018082",
-    "coordinates": [
-      -73.95911529,
-      40.65245679
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018083",
-    "coordinates": [
-      -73.95850153,
-      40.65002892
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018085",
-    "coordinates": [
-      -73.958291,
-      40.649115
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018086",
-    "coordinates": [
-      -73.95820347,
-      40.64617918
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018087",
-    "coordinates": [
-      -73.95814408,
-      40.6452617
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018088",
-    "coordinates": [
-      -73.95805063,
-      40.64788737
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018090",
-    "coordinates": [
-      -73.95799026,
-      40.64394086
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018092",
-    "coordinates": [
-      -73.957793,
-      40.671355
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018095",
-    "coordinates": [
-      -73.95682638,
-      40.67403887
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018096",
-    "coordinates": [
-      -73.956281,
-      40.675141
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018097",
-    "coordinates": [
-      -73.95621158,
-      40.67574507
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018099",
-    "coordinates": [
-      -73.955858,
-      40.676714
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018100",
-    "coordinates": [
-      -73.958535,
-      40.681853
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018101",
-    "coordinates": [
-      -73.95620126,
-      40.68131525
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018102",
-    "coordinates": [
-      -73.95570356,
-      40.68095126
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018103",
-    "coordinates": [
-      -73.955431,
-      40.679506
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018105",
-    "coordinates": [
-      -73.949473,
-      40.679987
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018109",
-    "coordinates": [
-      -73.94615493,
-      40.68027266
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018110",
-    "coordinates": [
-      -73.94490293,
-      40.68019738
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018111",
-    "coordinates": [
-      -73.94226,
-      40.680059
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018115",
-    "coordinates": [
-      -73.93910101,
-      40.67975193
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018117",
-    "coordinates": [
-      -73.937627,
-      40.67981536
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018119",
-    "coordinates": [
-      -73.93549973,
-      40.67956068
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018120",
-    "coordinates": [
-      -73.929834,
-      40.679381
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018124",
-    "coordinates": [
-      -73.921802,
-      40.679015
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018133",
-    "coordinates": [
-      -73.91218476,
-      40.67828559
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018134",
-    "coordinates": [
-      -73.91025266,
-      40.67831185
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018136",
-    "coordinates": [
-      -73.90761958,
-      40.67803579
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018137",
-    "coordinates": [
-      -73.871648,
-      40.733579
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018138",
-    "coordinates": [
-      -73.87270949,
-      40.73388902
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018140",
-    "coordinates": [
-      -73.873658,
-      40.734162
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018141",
-    "coordinates": [
-      -73.87625423,
-      40.7353874
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018142",
-    "coordinates": [
-      -73.877364,
-      40.736273
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018143",
-    "coordinates": [
-      -73.880315,
-      40.736982
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018144",
-    "coordinates": [
-      -73.883978,
-      40.737777
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018146",
-    "coordinates": [
-      -73.892498,
-      40.739393
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018147",
-    "coordinates": [
-      -73.895296,
-      40.739922
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018148",
-    "coordinates": [
-      -73.899864,
-      40.740727
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018149",
-    "coordinates": [
-      -73.901886,
-      40.740962
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018153",
-    "coordinates": [
-      -73.906524,
-      40.741506
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018155",
-    "coordinates": [
-      -73.90753416,
-      40.74143396
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018157",
-    "coordinates": [
-      -73.91534245,
-      40.74254629
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018161",
-    "coordinates": [
-      -73.92240124,
-      40.74331229
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018166",
-    "coordinates": [
-      -73.924156,
-      40.743555
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018172",
-    "coordinates": [
-      -73.933726,
-      40.744608
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018177",
-    "coordinates": [
-      -73.94344594,
-      40.83074624
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018179",
-    "coordinates": [
-      -73.94470427,
-      40.82938949
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018185",
-    "coordinates": [
-      -73.95528026,
-      40.81453869
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018187",
-    "coordinates": [
-      -73.95336989,
-      40.81715705
-    ],
-    "status": "installed"
-  },
-  {
-    "id": "LINK-018189",
-    "coordinates": [
-      -73.95187039,
-      40.81886798
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018196",
-    "coordinates": [
-      -73.95637382,
-      40.81802286
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018198",
-    "coordinates": [
-      -73.94279179,
-      40.74707469
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018199",
-    "coordinates": [
-      -73.94413828,
-      40.74663918
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018200",
-    "coordinates": [
-      -73.94524605,
-      40.74608863
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018201",
-    "coordinates": [
-      -73.94693708,
-      40.74541772
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018203",
-    "coordinates": [
-      -73.94766296,
-      40.74492115
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018206",
-    "coordinates": [
-      -73.95080577,
-      40.74338234
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018207",
-    "coordinates": [
-      -73.95267766,
-      40.74263091
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018209",
-    "coordinates": [
-      -73.95333647,
-      40.74228717
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018218",
-    "coordinates": [
-      -73.92788597,
-      40.81015856
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018220",
-    "coordinates": [
-      -73.92888643,
-      40.81751219
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018221",
-    "coordinates": [
-      -73.92924285,
-      40.81675164
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018222",
-    "coordinates": [
-      -73.92988537,
-      40.81503931
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018223",
-    "coordinates": [
-      -73.930217,
-      40.81431
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018224",
-    "coordinates": [
-      -73.93040028,
-      40.81359474
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018225",
-    "coordinates": [
-      -73.92925029,
-      40.81244091
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018226",
-    "coordinates": [
-      -73.92866453,
-      40.81225338
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018228",
-    "coordinates": [
-      -73.92907378,
-      40.80854426
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018373",
-    "coordinates": [
-      -73.93976524,
-      40.79878582
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018375",
-    "coordinates": [
-      -73.9445962,
-      40.79189835
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018377",
-    "coordinates": [
-      -73.93860514,
-      40.80009573
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018381",
-    "coordinates": [
-      -74.10895942,
-      40.57143702
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018382",
-    "coordinates": [
-      -74.10861367,
-      40.57178152
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018383",
-    "coordinates": [
-      -74.10753883,
-      40.57285047
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018384",
-    "coordinates": [
-      -74.10691685,
-      40.57346599
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018385",
-    "coordinates": [
-      -74.1048165,
-      40.57555318
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018386",
-    "coordinates": [
-      -74.10356538,
-      40.57681082
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018388",
-    "coordinates": [
-      -74.10065158,
-      40.57963412
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018389",
-    "coordinates": [
-      -74.1000124,
-      40.57983879
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018390",
-    "coordinates": [
-      -73.91292955,
-      40.84388121
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018391",
-    "coordinates": [
-      -73.91979703,
-      40.83513298
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018394",
-    "coordinates": [
-      -73.9099,
-      40.84833
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018397",
-    "coordinates": [
-      -73.8974,
-      40.86115
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018398",
-    "coordinates": [
-      -73.8928,
-      40.86487
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018400",
-    "coordinates": [
-      -73.90051187,
-      40.86366546
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018402",
-    "coordinates": [
-      -73.9021009,
-      40.86869849
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018403",
-    "coordinates": [
-      -73.89780278,
-      40.86676519
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018405",
-    "coordinates": [
-      -74.08382835,
-      40.59771508
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018406",
-    "coordinates": [
-      -74.08305039,
-      40.59800199
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018407",
-    "coordinates": [
-      -74.11201028,
-      40.581304
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018408",
-    "coordinates": [
-      -74.11135039,
-      40.58167685
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018409",
-    "coordinates": [
-      -74.10370822,
-      40.58738523
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018410",
-    "coordinates": [
-      -74.101684,
-      40.589032
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018411",
-    "coordinates": [
-      -74.10127071,
-      40.58948831
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018414",
-    "coordinates": [
-      -74.10090436,
-      40.58990771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018415",
-    "coordinates": [
-      -74.10092195,
-      40.59045311
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-018416",
-    "coordinates": [
-      -74.10086158,
-      40.59143558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019312",
-    "coordinates": [
-      -73.912958,
-      40.846434
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019313",
-    "coordinates": [
-      -73.91213693,
-      40.84779956
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019315",
-    "coordinates": [
-      -73.91028173,
-      40.850173
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019363",
-    "coordinates": [
-      -73.9495225,
-      40.67948543
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019365",
-    "coordinates": [
-      -73.949579,
-      40.678818
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019366",
-    "coordinates": [
-      -73.94969703,
-      40.677504
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019368",
-    "coordinates": [
-      -73.9502139,
-      40.67211449
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019369",
-    "coordinates": [
-      -73.9505023,
-      40.66916742
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019371",
-    "coordinates": [
-      -73.950605,
-      40.662438
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019377",
-    "coordinates": [
-      -74.115318,
-      40.564789
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019378",
-    "coordinates": [
-      -73.91603242,
-      40.84220263
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019379",
-    "coordinates": [
-      -73.91496083,
-      40.84425807
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019724",
-    "coordinates": [
-      -73.84588685,
-      40.72073474
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019773",
-    "coordinates": [
-      -73.84560657,
-      40.72117684
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019776",
-    "coordinates": [
-      -73.93995198,
-      40.7481039
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019781",
-    "coordinates": [
-      -73.93494274,
-      40.75114906
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019782",
-    "coordinates": [
-      -73.93415739,
-      40.75149813
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019783",
-    "coordinates": [
-      -73.93337963,
-      40.75195044
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019837",
-    "coordinates": [
-      -73.944183,
-      40.819549
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019889",
-    "coordinates": [
-      -73.923341,
-      40.761089
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019890",
-    "coordinates": [
-      -73.92076317,
-      40.75972324
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019891",
-    "coordinates": [
-      -73.91723,
-      40.758221
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019892",
-    "coordinates": [
-      -73.9143831,
-      40.75672431
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019897",
-    "coordinates": [
-      -73.87812993,
-      40.73933161
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019899",
-    "coordinates": [
-      -73.87936018,
-      40.74073714
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019900",
-    "coordinates": [
-      -73.87992485,
-      40.74093675
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019901",
-    "coordinates": [
-      -73.8829233,
-      40.74302376
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019902",
-    "coordinates": [
-      -73.88378879,
-      40.74356322
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019903",
-    "coordinates": [
-      -73.88945075,
-      40.74576092
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-019904",
-    "coordinates": [
-      -73.89012129,
-      40.74604558
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020239",
-    "coordinates": [
-      -73.971614,
-      40.75694469
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020490",
-    "coordinates": [
-      -73.97313741,
-      40.7853501
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020492",
-    "coordinates": [
-      -73.96827641,
-      40.75501502
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020495",
-    "coordinates": [
-      -73.92262283,
-      40.80966819
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020496",
-    "coordinates": [
-      -73.91900611,
-      40.80775593
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020497",
-    "coordinates": [
-      -73.91624535,
-      40.80638485
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020504",
-    "coordinates": [
-      -73.91295433,
-      40.81447081
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020509",
-    "coordinates": [
-      -73.91795518,
-      40.80628664
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020513",
-    "coordinates": [
-      -73.91518065,
-      40.81439418
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020515",
-    "coordinates": [
-      -73.91607435,
-      40.81284091
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020541",
-    "coordinates": [
-      -73.92333228,
-      40.80829273
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020548",
-    "coordinates": [
-      -73.91834301,
-      40.80710778
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020557",
-    "coordinates": [
-      -73.91396042,
-      40.83573444
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020563",
-    "coordinates": [
-      -73.92192323,
-      40.8102552
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020565",
-    "coordinates": [
-      -73.9205525,
-      40.81212659
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020569",
-    "coordinates": [
-      -73.91616313,
-      40.81939415
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020572",
-    "coordinates": [
-      -73.91484908,
-      40.82211198
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020576",
-    "coordinates": [
-      -73.91195254,
-      40.82202219
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020581",
-    "coordinates": [
-      -73.89639316,
-      40.84647676
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020595",
-    "coordinates": [
-      -73.91707813,
-      40.81737983
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020596",
-    "coordinates": [
-      -73.91679096,
-      40.81801655
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020598",
-    "coordinates": [
-      -73.91069013,
-      40.82251879
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020599",
-    "coordinates": [
-      -73.90942748,
-      40.82233792
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020603",
-    "coordinates": [
-      -73.92658962,
-      40.81207894
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020604",
-    "coordinates": [
-      -73.92624362,
-      40.81255748
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020653",
-    "coordinates": [
-      -73.9887287,
-      40.68940822
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020655",
-    "coordinates": [
-      -73.991014,
-      40.686177
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020657_Old",
-    "coordinates": [
-      -73.99158104,
-      40.68479895
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020658",
-    "coordinates": [
-      -73.9921845,
-      40.68430374
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020659",
-    "coordinates": [
-      -73.99277254,
-      40.68343607
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020661",
-    "coordinates": [
-      -73.99346713,
-      40.68240987
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020756",
-    "coordinates": [
-      -73.95545319,
-      40.73691349
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020757",
-    "coordinates": [
-      -73.955096,
-      40.734684
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020759",
-    "coordinates": [
-      -73.954581,
-      40.732735
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020764",
-    "coordinates": [
-      -73.949671,
-      40.722328
-    ],
-    "status": "pending"
-  },
-  {
-    "id": "LINK-020767",
-    "coordinates": [
-      -73.947627,
-      40.720111
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020768",
-    "coordinates": [
-      -73.946853,
-      40.719511
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020772",
-    "coordinates": [
-      -73.94373207,
-      40.7110789
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020774",
-    "coordinates": [
-      -73.943399,
-      40.707379
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020775",
-    "coordinates": [
-      -73.94303,
-      40.705768
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020776",
-    "coordinates": [
-      -73.942989,
-      40.704496
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020781",
-    "coordinates": [
-      -73.99378509,
-      40.68657135
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020783",
-    "coordinates": [
-      -73.99476547,
-      40.68455252
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020785",
-    "coordinates": [
-      -73.99541762,
-      40.68317963
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020833",
-    "coordinates": [
-      -73.93221564,
-      40.75371822
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020907",
-    "coordinates": [
-      -73.918518,
-      40.762073
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020914",
-    "coordinates": [
-      -73.91450114,
-      40.7535215
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020922",
-    "coordinates": [
-      -73.9177028,
-      40.75374563
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020927",
-    "coordinates": [
-      -73.92659983,
-      40.75234817
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020928",
-    "coordinates": [
-      -73.927183,
-      40.752724
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020932",
-    "coordinates": [
-      -73.91840166,
-      40.75364064
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020933",
-    "coordinates": [
-      -73.92521461,
-      40.75652086
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020949",
-    "coordinates": [
-      -73.92577772,
-      40.77203314
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020959",
-    "coordinates": [
-      -73.922478,
-      40.763931
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020960",
-    "coordinates": [
-      -73.921267,
-      40.763207
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020965",
-    "coordinates": [
-      -73.9190056,
-      40.74130348
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020984",
-    "coordinates": [
-      -73.919579,
-      40.762564
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-020994",
-    "coordinates": [
-      -73.95348371,
-      40.74432049
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021013",
-    "coordinates": [
-      -73.92035427,
-      40.77074708
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021014",
-    "coordinates": [
-      -73.92149601,
-      40.7710546
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021018",
-    "coordinates": [
-      -73.91557,
-      40.760686
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021020",
-    "coordinates": [
-      -73.91981871,
-      40.75413552
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021068",
-    "coordinates": [
-      -73.950086,
-      40.747793
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021069",
-    "coordinates": [
-      -73.949855,
-      40.748497
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021089",
-    "coordinates": [
-      -73.91889468,
-      40.77035989
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021097",
-    "coordinates": [
-      -73.92244782,
-      40.7552199
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021107",
-    "coordinates": [
-      -73.95131072,
-      40.71086983
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021118",
-    "coordinates": [
-      -73.95953976,
-      40.71385109
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021119",
-    "coordinates": [
-      -73.96274067,
-      40.71522663
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021122",
-    "coordinates": [
-      -73.95861248,
-      40.71924622
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021123",
-    "coordinates": [
-      -73.95155241,
-      40.71419088
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021136",
-    "coordinates": [
-      -73.95128474,
-      40.71307988
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021137",
-    "coordinates": [
-      -73.95102615,
-      40.71166636
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021138",
-    "coordinates": [
-      -73.95070637,
-      40.70957163
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021150",
-    "coordinates": [
-      -73.95323355,
-      40.7230135
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021156",
-    "coordinates": [
-      -73.95468869,
-      40.72253263
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021157",
-    "coordinates": [
-      -73.96244,
-      40.7099
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021162",
-    "coordinates": [
-      -73.96128653,
-      40.71643057
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021163",
-    "coordinates": [
-      -73.96030116,
-      40.71765823
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021194",
-    "coordinates": [
-      -73.97437496,
-      40.68064989
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021224",
-    "coordinates": [
-      -73.96799938,
-      40.68042562
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021227",
-    "coordinates": [
-      -73.96276535,
-      40.71906736
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021228",
-    "coordinates": [
-      -73.96424309,
-      40.71573175
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021229",
-    "coordinates": [
-      -73.95561039,
-      40.71226766
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021230",
-    "coordinates": [
-      -73.95028299,
-      40.71412964
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021233",
-    "coordinates": [
-      -73.9610955,
-      40.71449771
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021234",
-    "coordinates": [
-      -73.95723131,
-      40.71851349
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021241",
-    "coordinates": [
-      -73.95531649,
-      40.707581
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021248",
-    "coordinates": [
-      -73.96693042,
-      40.71391386
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021262",
-    "coordinates": [
-      -73.9592022,
-      40.72250424
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021263",
-    "coordinates": [
-      -73.96047431,
-      40.71940433
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021265",
-    "coordinates": [
-      -73.96084076,
-      40.71684975
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021279",
-    "coordinates": [
-      -73.96035235,
-      40.72138255
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021280",
-    "coordinates": [
-      -73.95977484,
-      40.72194342
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021284",
-    "coordinates": [
-      -73.95260309,
-      40.72329009
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021289",
-    "coordinates": [
-      -73.96853381,
-      40.71098811
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021303",
-    "coordinates": [
-      -73.96652497,
-      40.71470734
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021329",
-    "coordinates": [
-      -73.919173,
-      40.76578525
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021330",
-    "coordinates": [
-      -73.91836041,
-      40.76540165
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021332",
-    "coordinates": [
-      -73.91171708,
-      40.76227762
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021381",
-    "coordinates": [
-      -73.86501478,
-      40.69173379
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021385",
-    "coordinates": [
-      -73.853678,
-      40.693166
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021386",
-    "coordinates": [
-      -73.85255707,
-      40.69373978
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021387",
-    "coordinates": [
-      -73.85056916,
-      40.69414034
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021389",
-    "coordinates": [
-      -73.84858743,
-      40.69467595
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021390",
-    "coordinates": [
-      -73.84665595,
-      40.69504845
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021393",
-    "coordinates": [
-      -73.84118746,
-      40.69522138
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021394",
-    "coordinates": [
-      -73.84055056,
-      40.69541981
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021395",
-    "coordinates": [
-      -73.83880988,
-      40.69591252
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021396",
-    "coordinates": [
-      -73.83784205,
-      40.69633127
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021397",
-    "coordinates": [
-      -73.837293,
-      40.697047
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021398",
-    "coordinates": [
-      -73.83565709,
-      40.69790215
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021399",
-    "coordinates": [
-      -73.83484675,
-      40.69809542
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021403",
-    "coordinates": [
-      -73.82709687,
-      40.70063483
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021406",
-    "coordinates": [
-      -73.8564538,
-      40.69260724
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021504",
-    "coordinates": [
-      -73.977038,
-      40.681596
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021505",
-    "coordinates": [
-      -73.978034,
-      40.680323
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021506",
-    "coordinates": [
-      -73.97846492,
-      40.67950101
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021509",
-    "coordinates": [
-      -73.981469,
-      40.675254
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021511",
-    "coordinates": [
-      -73.98316142,
-      40.6726791
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021512",
-    "coordinates": [
-      -73.98362685,
-      40.67224181
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021516",
-    "coordinates": [
-      -73.987509,
-      40.667873
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021517",
-    "coordinates": [
-      -73.98837832,
-      40.66653858
-    ],
-    "status": "active"
-  },
-  {
-    "id": "LINK-021518",
+    "street_address": "258 14 STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145902",
     "coordinates": [
       -73.98905662,
       40.66622971
@@ -14592,95 +10,469 @@
     "status": "active"
   },
   {
-    "id": "LINK-021519",
+    "street_address": "36 RIVINGTON STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-158821",
     "coordinates": [
-      -73.991789,
-      40.666904
+      -73.9913664,
+      40.7211101
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021520",
+    "street_address": "333 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133690",
     "coordinates": [
-      -73.993715,
-      40.664406
+      -73.98503716,
+      40.74762726
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021522",
+    "street_address": "339 LIVINGSTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126506",
     "coordinates": [
-      -73.996017,
-      40.662189
+      -73.98042355,
+      40.68764898
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021524",
+    "street_address": "2596 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-135865",
     "coordinates": [
-      -73.999532,
-      40.658808
+      -73.9707519,
+      40.7957738
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021525",
+    "street_address": "600 WEST 162 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120334",
     "coordinates": [
-      -74.000689,
-      40.657704
+      -73.942876,
+      40.837241
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021526",
+    "street_address": "909 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121836",
     "coordinates": [
-      -74.002053,
-      40.656384
+      -73.9687589,
+      40.75837712
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021527",
+    "street_address": "1995 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-137852",
     "coordinates": [
-      -74.00305032,
-      40.6554376
+      -73.950557,
+      40.805615
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021528",
+    "street_address": "1760 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-134111",
     "coordinates": [
-      -74.00440376,
-      40.65413323
+      -73.9466648,
+      40.82670709
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021535",
+    "street_address": "400 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122061",
     "coordinates": [
-      -73.83136082,
-      40.70753055
+      -73.995245,
+      40.749537
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021536",
+    "street_address": "72-30 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-111010",
     "coordinates": [
-      -73.83157897,
-      40.70615073
+      -73.89253173,
+      40.74667176
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021538",
+    "street_address": "155 WEST 68 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-138046",
     "coordinates": [
-      -73.9116866,
-      40.75448755
+      -73.983247,
+      40.775999
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021680",
+    "street_address": "1339 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-134849",
+    "coordinates": [
+      -73.93583333,
+      40.84662333
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2381 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145734",
+    "coordinates": [
+      -74.10753883,
+      40.57285047
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1175 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121756",
+    "coordinates": [
+      -73.96315851,
+      40.76241687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "68 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-137382",
+    "coordinates": [
+      -73.989403,
+      40.726049
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "252 EAST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121789",
+    "coordinates": [
+      -73.96782908,
+      40.75617415
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 149 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120354",
+    "coordinates": [
+      -73.94886891,
+      40.82903713
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "700 FAILE STREET",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-106058",
+    "coordinates": [
+      -73.886191,
+      40.8147397
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1175 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120983",
+    "coordinates": [
+      -73.961971,
+      40.767655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3418 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-114742",
+    "coordinates": [
+      -73.869636,
+      40.684317
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "65-10 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145742",
+    "coordinates": [
+      -73.899864,
+      40.740727
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "755 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120526",
+    "coordinates": [
+      -73.969837,
+      40.794604
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2150 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-109544",
+    "coordinates": [
+      -73.980961,
+      40.781474
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "989 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-144139",
+    "coordinates": [
+      -73.98256354,
+      40.76735759
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1961 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-126647",
+    "coordinates": [
+      -73.916507,
+      40.678654
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2154 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-146099",
+    "coordinates": [
+      -74.10267054,
+      40.57739083
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3480 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111652",
+    "coordinates": [
+      -73.951597,
+      40.824559
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141541",
+    "coordinates": [
+      -73.79680056,
+      40.70460911
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2239 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-137841",
+    "coordinates": [
+      -73.937249,
+      40.80154018
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "455 FRONT STREET",
+    "type": "LINK1.0",
+    "id": "si-01-153319",
+    "coordinates": [
+      -74.0741115,
+      40.6271925
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-143435",
+    "coordinates": [
+      -73.91801561,
+      40.75859125
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "146-64 LIBERTY AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-118455",
+    "coordinates": [
+      -73.8045508,
+      40.6959629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3159 BAINBRIDGE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-119707",
+    "coordinates": [
+      -73.8796393,
+      40.8749145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2010 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119961",
+    "coordinates": [
+      -73.95075428,
+      40.80595028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "384 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135679",
+    "coordinates": [
+      -73.98115859,
+      40.73737306
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3125 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146044",
+    "coordinates": [
+      -73.91195254,
+      40.82202219
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-108373",
+    "coordinates": [
+      -73.926808,
+      40.76272
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2431 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121295",
+    "coordinates": [
+      -73.97481,
+      40.790818
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "932 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122627",
+    "coordinates": [
+      -73.983593,
+      40.765522
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "552 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-135169",
+    "coordinates": [
+      -73.98813678,
+      40.75459325
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3097 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-144251",
+    "coordinates": [
+      -73.912327,
+      40.821437
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 ORCHARD STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-137173",
+    "coordinates": [
+      -73.98908323,
+      40.72048554
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "754 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121816",
+    "coordinates": [
+      -73.972326,
+      40.753899
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1578 UNION STREET",
+    "type": "LINK1.0",
+    "id": "bk-09-153434",
+    "coordinates": [
+      -73.9368437,
+      40.6679423
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "75-20 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-137921",
+    "coordinates": [
+      -73.88970545,
+      40.74696638
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "233 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133695",
+    "coordinates": [
+      -73.98754894,
+      40.74417468
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43-01 48 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145981",
     "coordinates": [
       -73.92206966,
       40.73968025
@@ -14688,143 +480,1147 @@
     "status": "active"
   },
   {
-    "id": "LINK-021683",
+    "street_address": "730 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134708",
     "coordinates": [
-      -73.97573017,
-      40.68103872
+      -73.96800953,
+      40.79237863
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021686",
+    "street_address": "110 MAIDEN LANE",
+    "type": "LINK1.0",
+    "id": "mn-01-123076",
     "coordinates": [
-      -73.96775318,
-      40.68226753
+      -74.00624351,
+      40.70624185
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021687",
+    "street_address": "82-03 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-125337",
     "coordinates": [
-      -73.96466835,
-      40.68088788
+      -73.88366475,
+      40.74772878
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021688",
+    "street_address": "481 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134611",
     "coordinates": [
-      -73.96451072,
-      40.68023805
+      -73.97907885,
+      40.74061156
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021689",
+    "street_address": "681 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121424",
     "coordinates": [
-      -73.96373,
-      40.67854
+      -73.97468574,
+      40.74665132
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021803",
+    "street_address": "76-23 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145885",
     "coordinates": [
-      -73.87355043,
-      40.74879795
+      -73.86501478,
+      40.69173379
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021901",
+    "street_address": "1965 HUGHES AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-119558",
     "coordinates": [
-      -73.96138086,
-      40.76842289
+      -73.89219433,
+      40.84618976
+    ],
+    "status": "installed"
+  },
+  {
+    "street_address": "535 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-126569",
+    "coordinates": [
+      -73.960581,
+      40.660852
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021914",
+    "street_address": "828 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-139462",
     "coordinates": [
-      -73.86809486,
-      40.69102143
+      -73.986052,
+      40.762151
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021919",
+    "street_address": "213 UNION AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-108703",
     "coordinates": [
-      -73.872079,
-      40.683506
+      -73.95052895,
+      40.70682217
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021920",
+    "street_address": "216 WEST 103 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120393",
     "coordinates": [
-      -73.87137973,
-      40.68382059
+      -73.968326,
+      40.798954
+    ]
+  },
+  {
+    "street_address": "101 EAST 31 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121567",
+    "coordinates": [
+      -73.98250633,
+      40.74514234
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021921",
+    "street_address": "1 ST. LUKE'S PLACE",
+    "type": "LINK1.0",
+    "id": "mn-02-123600",
     "coordinates": [
-      -73.87053741,
-      40.68406084
+      -74.00662855,
+      40.73025769
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021922",
+    "street_address": "545 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122426",
     "coordinates": [
-      -73.86897453,
-      40.68462509
+      -73.9966041,
+      40.73788645
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021923",
+    "street_address": "37-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-142875",
     "coordinates": [
-      -73.86830879,
-      40.68470155
+      -73.927772,
+      40.743976
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021925",
+    "street_address": "2736 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134112",
     "coordinates": [
-      -73.86677733,
-      40.68513094
+      -73.96783287,
+      40.80030025
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021926",
+    "street_address": "86-43 LEFFERTS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-09-124777",
     "coordinates": [
-      -73.89716745,
-      40.67647467
+      -73.8309137,
+      40.70015865
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021927",
+    "street_address": "124-05 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-108790",
     "coordinates": [
-      -73.89746353,
-      40.67722165
+      -73.82620488,
+      40.70092643
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021928",
+    "street_address": "710 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145752",
     "coordinates": [
-      -73.89835842,
-      40.67699412
+      -73.97332,
+      40.685787
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021929",
+    "street_address": "2690 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119898",
+    "coordinates": [
+      -73.9426993,
+      40.82159551
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2340 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119948",
+    "coordinates": [
+      -73.94284249,
+      40.81677995
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160 EAST 38 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-136202",
+    "coordinates": [
+      -73.97653468,
+      40.74828704
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1540 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120664",
+    "coordinates": [
+      -73.9308176,
+      40.85312181
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "319 EAST 204 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-119713",
+    "coordinates": [
+      -73.8780848,
+      40.8725809
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "601 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-146054",
+    "coordinates": [
+      -73.91624535,
+      40.80638485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "84-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-03-125413",
+    "coordinates": [
+      -73.8834031,
+      40.7555251
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "718 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120610",
+    "coordinates": [
+      -73.97104466,
+      40.79331
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1910 VICTORY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "si-01-159857",
+    "coordinates": [
+      -74.1277241,
+      40.6125409
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33-10 ASTORIA BOULEVARD SOUTH",
+    "type": "LINK1.0",
+    "id": "qu-01-125163",
+    "coordinates": [
+      -73.91667316,
+      40.76970698
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "72 EAST 161 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119159",
+    "coordinates": [
+      -73.92522252,
+      40.82735593
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "172 EAST 24 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121489",
+    "coordinates": [
+      -73.982889,
+      40.739531
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "482 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145873",
+    "coordinates": [
+      -73.987509,
+      40.667873
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "338 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121161",
+    "coordinates": [
+      -73.97693216,
+      40.78014761
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "195 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-137026",
+    "coordinates": [
+      -74.00813878,
+      40.72311759
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "462 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-107832",
+    "coordinates": [
+      -73.97404944,
+      40.78409642
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "19 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-115304",
+    "coordinates": [
+      -73.9883901,
+      40.72357993
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3 WEST 31 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-107760",
+    "coordinates": [
+      -73.98620711,
+      40.74670887
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101-10 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124204",
+    "coordinates": [
+      -73.85251864,
+      40.72624127
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "944 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121677",
+    "coordinates": [
+      -73.96518956,
+      40.75499065
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2480 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142855",
+    "coordinates": [
+      -73.9478767,
+      40.81486349
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 EAST 63 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121697",
+    "coordinates": [
+      -73.95999822,
+      40.76199324
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1373 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145815",
+    "coordinates": [
+      -73.94615493,
+      40.68027266
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1755 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145825",
+    "coordinates": [
+      -74.10370822,
+      40.58738523
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "891 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122620",
+    "coordinates": [
+      -73.984767,
+      40.764338
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135855",
+    "coordinates": [
+      -73.99915027,
+      40.73910655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "638 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-133679",
+    "coordinates": [
+      -73.97002379,
+      40.78962178
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "89-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-124921",
+    "coordinates": [
+      -73.87470458,
+      40.73454516
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "575 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145831",
+    "coordinates": [
+      -73.94969703,
+      40.677504
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2208 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-126638",
+    "coordinates": [
+      -73.908374,
+      40.678079
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "221 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133664",
+    "coordinates": [
+      -73.98003507,
+      40.74582381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2943 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-137848",
+    "coordinates": [
+      -73.964488,
+      40.807508
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "190-50 99 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-158794",
+    "coordinates": [
+      -73.7662011,
+      40.7099171
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1030 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-136989",
+    "coordinates": [
+      -73.965653,
+      40.763037
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46-45 VERNON BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-125015",
+    "coordinates": [
+      -73.95296626,
+      40.74549641
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1896 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120225",
+    "coordinates": [
+      -73.945348,
+      40.790862
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "155 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121529",
+    "coordinates": [
+      -73.9755338,
+      40.74960493
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "793 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121133",
+    "coordinates": [
+      -73.967597,
+      40.768649
+    ]
+  },
+  {
+    "street_address": "1347 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-134739",
+    "coordinates": [
+      -73.95822043,
+      40.77281462
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "652A MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-111740",
+    "coordinates": [
+      -73.91644985,
+      40.81876868
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2215 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-120046",
+    "coordinates": [
+      -73.945458,
+      40.812611
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "108-36 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145845",
+    "coordinates": [
+      -73.84284541,
+      40.72067138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "303 WEST 39 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-136982",
+    "coordinates": [
+      -73.991425,
+      40.7555
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "892 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134118",
+    "coordinates": [
+      -73.96912972,
+      40.75827505
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2660 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119886",
+    "coordinates": [
+      -73.94328498,
+      40.82079611
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-20 SUTPHIN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-124571",
+    "coordinates": [
+      -73.806622,
+      40.698501
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-109262",
+    "coordinates": [
+      -73.94291758,
+      40.70506042
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29-24 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-108362",
+    "coordinates": [
+      -73.92268748,
+      40.76743258
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-123299",
+    "coordinates": [
+      -73.9842789,
+      40.7403098
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "147 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120927",
+    "coordinates": [
+      -73.981404,
+      40.773657
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2463 VALENTINE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119648",
+    "coordinates": [
+      -73.89644355,
+      40.86117438
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "545 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145843",
+    "coordinates": [
+      -73.949579,
+      40.678818
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2066 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145807",
+    "coordinates": [
+      -74.1000124,
+      40.57983879
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 UTICA AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-151273",
+    "coordinates": [
+      -73.9311434,
+      40.6677063
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2570 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142554",
+    "coordinates": [
+      -73.93750775,
+      40.8240811
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "124 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138539",
+    "coordinates": [
+      -73.977306,
+      40.750237
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "985 BRUCKNER BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-02-145558",
+    "coordinates": [
+      -73.8910895,
+      40.8201151
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1860 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133501",
+    "coordinates": [
+      -73.98192926,
+      40.76981619
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1515 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-133354",
+    "coordinates": [
+      -73.98587842,
+      40.75766558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "127 WEST BURNSIDE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-05-119612",
+    "coordinates": [
+      -73.9140421,
+      40.8539059
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "705 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-108485",
+    "coordinates": [
+      -73.98877954,
+      40.75883097
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "250 CHURCH STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-122275",
+    "coordinates": [
+      -74.00581491,
+      40.71780497
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118-04 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-135034",
+    "coordinates": [
+      -73.83160899,
+      40.69975447
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-02 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146068",
+    "coordinates": [
+      -73.927183,
+      40.752724
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3270 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-146058",
+    "coordinates": [
+      -73.95637382,
+      40.81802286
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "146 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123812",
+    "coordinates": [
+      -73.987081,
+      40.729236
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "189 SHERMAN AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120719",
+    "coordinates": [
+      -73.9216654,
+      40.865079
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "927 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145836",
+    "coordinates": [
+      -73.958291,
+      40.649115
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "739 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122580",
+    "coordinates": [
+      -73.98797229,
+      40.75993686
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2697 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134421",
+    "coordinates": [
+      -73.96880907,
+      40.79904235
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "718 WASHINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-125707",
+    "coordinates": [
+      -73.96361018,
+      40.67640751
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "219 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123288",
+    "coordinates": [
+      -73.98309797,
+      40.73083305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1164 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135943",
+    "coordinates": [
+      -73.96321301,
+      40.7619766
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "909 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121854",
+    "coordinates": [
+      -73.96841698,
+      40.75881998
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 WEST 56 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122853",
+    "coordinates": [
+      -73.97473228,
+      40.76246755
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 WEST 109 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120268",
+    "coordinates": [
+      -73.967381,
+      40.803721
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "546 WEST 147 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120434",
+    "coordinates": [
+      -73.949288,
+      40.82758
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "477 WEST 141 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120571",
+    "coordinates": [
+      -73.94925939,
+      40.82266347
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-126657",
+    "coordinates": [
+      -73.942287,
+      40.702247
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4240 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120803",
+    "coordinates": [
+      -73.9361795,
+      40.8495879
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134536",
+    "coordinates": [
+      -73.98389,
+      40.737597
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-01 31 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146037",
+    "coordinates": [
+      -73.918518,
+      40.762073
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "206 EAST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-134748",
+    "coordinates": [
+      -73.95371545,
+      40.77860514
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "580 WEST 156 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120451",
+    "coordinates": [
+      -73.94509159,
+      40.83328532
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "95 EAST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-108257",
+    "coordinates": [
+      -73.943527,
+      40.799528
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "928 LONGWOOD AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-152409",
+    "coordinates": [
+      -73.8994977,
+      40.8180479
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "888 Westchester Avenue",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-152007",
+    "coordinates": [
+      -73.8989841,
+      40.8208057
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "178 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-146091",
+    "coordinates": [
+      -73.96244,
+      40.7099
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1617 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111857",
+    "coordinates": [
+      -73.92940254,
+      40.85541608
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "137 EAST 24 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138284",
+    "coordinates": [
+      -73.98392453,
+      40.74009245
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "42-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-136586",
+    "coordinates": [
+      -73.92071953,
+      40.75312177
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2001 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134469",
+    "coordinates": [
+      -73.98235021,
+      40.77579496
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "425 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-120512",
+    "coordinates": [
+      -73.99915159,
+      40.73439251
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "159-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141549",
+    "coordinates": [
+      -73.799923,
+      40.703352
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "623 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123585",
+    "coordinates": [
+      -74.00567121,
+      40.73827778
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "22 GEORGIA AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-05-145936",
     "coordinates": [
       -73.89921208,
       40.67704253
@@ -14832,31 +1628,2974 @@
     "status": "active"
   },
   {
-    "id": "LINK-021930",
+    "street_address": "31-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125085",
     "coordinates": [
-      -73.90195137,
-      40.67754
+      -73.92505031,
+      40.76189688
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021931",
+    "street_address": "93-19 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136656",
     "coordinates": [
-      -73.90299005,
-      40.67789498
+      -73.8729333,
+      40.7488692
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021932",
+    "street_address": "30 EAST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-145690",
     "coordinates": [
-      -73.90430067,
-      40.67786155
+      -73.896537,
+      40.867038
     ],
     "status": "active"
   },
   {
-    "id": "LINK-021933",
+    "street_address": "801 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-108008",
+    "coordinates": [
+      -73.968849,
+      40.795951
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "111-18 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-118521",
+    "coordinates": [
+      -73.7809523,
+      40.6940548
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32 EAST 50 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121950",
+    "coordinates": [
+      -73.97543366,
+      40.75773384
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "717 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134599",
+    "coordinates": [
+      -73.9928116,
+      40.7430973
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2640 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133626",
+    "coordinates": [
+      -73.96965239,
+      40.79728379
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-65 95 STREET",
+    "type": "LINK1.0",
+    "id": "qu-03-139617",
+    "coordinates": [
+      -73.87181741,
+      40.74908967
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3037 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-108745",
+    "coordinates": [
+      -73.8792791,
+      40.8699055
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 WEST 87 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121259",
+    "coordinates": [
+      -73.971936,
+      40.787224
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "719 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122148",
+    "coordinates": [
+      -73.984131,
+      40.759713
+    ]
+  },
+  {
+    "street_address": "620 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-136376",
+    "coordinates": [
+      -73.9702839,
+      40.78926318
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2085 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133403",
+    "coordinates": [
+      -73.98205439,
+      40.77909594
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "103 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123524",
+    "coordinates": [
+      -74.00416971,
+      40.74280314
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110-88 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124181",
+    "coordinates": [
+      -73.838184,
+      40.718602
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "119-01 METROPOLITAN AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145982",
+    "coordinates": [
+      -73.83157897,
+      40.70615073
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50-01 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-140214",
+    "coordinates": [
+      -73.91232033,
+      40.75336987
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "58 WEST 72 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-144086",
+    "coordinates": [
+      -73.9786294,
+      40.77724121
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "498 WEST 53 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-139118",
+    "coordinates": [
+      -73.99026177,
+      40.7664369
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "462 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-135639",
+    "coordinates": [
+      -73.98276825,
+      40.74533995
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "189 EAST 117 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-146004",
+    "coordinates": [
+      -73.93976524,
+      40.79878582
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "737 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-144692",
+    "coordinates": [
+      -73.98369329,
+      40.76032636
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "220 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133525",
+    "coordinates": [
+      -73.98512348,
+      40.73633169
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-02 KEW GARDENS ROAD",
+    "type": "LINK1.0",
+    "id": "qu-09-124172",
+    "coordinates": [
+      -73.830838,
+      40.713983
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "261 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145842",
+    "coordinates": [
+      -73.930217,
+      40.81431
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160-10 89 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-152196",
+    "coordinates": [
+      -73.7999467,
+      40.7062332
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "241 CANAL STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-122330",
+    "coordinates": [
+      -74.000048,
+      40.71819776
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1675 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119830",
+    "coordinates": [
+      -73.9505618,
+      40.78328877
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "304 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-117250",
+    "coordinates": [
+      -73.982789,
+      40.673534
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1865 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-134427",
+    "coordinates": [
+      -73.94420042,
+      40.82973306
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2202 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121232",
+    "coordinates": [
+      -73.980253,
+      40.783191
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "240 Park Ave S",
+    "type": "LINK1.0",
+    "id": "mn-05-137211",
+    "coordinates": [
+      -73.9885843,
+      40.73796976
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3680 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111936",
+    "coordinates": [
+      -73.946986,
+      40.830876
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "829 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122470",
+    "coordinates": [
+      -73.98965898,
+      40.76778999
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "362 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122442",
+    "coordinates": [
+      -73.99248875,
+      40.74861534
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145891",
+    "coordinates": [
+      -73.977038,
+      40.681596
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "170 EAST 33 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-134852",
+    "coordinates": [
+      -73.97882096,
+      40.74509981
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1391 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-119141",
+    "coordinates": [
+      -73.918194,
+      40.840248
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "250 WEST 95 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120596",
+    "coordinates": [
+      -73.97256708,
+      40.79404227
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "31-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125131",
+    "coordinates": [
+      -73.92127596,
+      40.76676629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1595 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-134185",
+    "coordinates": [
+      -73.9848567,
+      40.76026604
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "731 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-108701",
+    "coordinates": [
+      -73.997387,
+      40.660871
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25-01 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145791",
+    "coordinates": [
+      -73.94279179,
+      40.74707469
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "20 EAST 35 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121649",
+    "coordinates": [
+      -73.9823716,
+      40.74832255
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "153-21 ROCKAWAY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-154374",
+    "coordinates": [
+      -73.7829113,
+      40.6701549
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "83-23 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-145913",
+    "coordinates": [
+      -73.87936018,
+      40.74073714
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "250 WEST 78 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121308",
+    "coordinates": [
+      -73.9808485,
+      40.78325962
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-137950",
+    "coordinates": [
+      -73.97651851,
+      40.7500145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43-60 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-145957",
+    "coordinates": [
+      -73.9177028,
+      40.75374563
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "230 BERRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146012",
+    "coordinates": [
+      -73.96274067,
+      40.71522663
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1460 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121023",
+    "coordinates": [
+      -73.955586,
+      40.776833
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2097 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-131051",
+    "coordinates": [
+      -73.95679626,
+      40.80260688
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 EAST 32 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121611",
+    "coordinates": [
+      -73.98524463,
+      40.74711441
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 87 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-136620",
+    "coordinates": [
+      -73.953327,
+      40.779367
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "74 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134450",
+    "coordinates": [
+      -73.99938138,
+      40.7391558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "170-05 LINDEN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-137875",
+    "coordinates": [
+      -73.7794748,
+      40.691655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "888 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122608",
+    "coordinates": [
+      -73.98471931,
+      40.76399635
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "126 EAST 183 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-102420",
+    "coordinates": [
+      -73.901091,
+      40.857756
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "475 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145859",
+    "coordinates": [
+      -73.947627,
+      40.720111
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "459 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121447",
+    "coordinates": [
+      -73.979693,
+      40.73976238
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133538",
+    "coordinates": [
+      -73.97973824,
+      40.75233526
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "203 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-123634",
+    "coordinates": [
+      -73.985322,
+      40.735626
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1771 PITKIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-156780",
+    "coordinates": [
+      -73.9078327,
+      40.670182
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1888 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120214",
+    "coordinates": [
+      -73.946262,
+      40.789608
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201-08 HOLLIS AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-124001",
+    "coordinates": [
+      -73.7563366,
+      40.706075
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98-38 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145766",
+    "coordinates": [
+      -73.856848,
+      40.72785
+    ]
+  },
+  {
+    "street_address": "1536 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111656",
+    "coordinates": [
+      -73.93100715,
+      40.85285737
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3846 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-111066",
+    "coordinates": [
+      -73.943186,
+      40.836081
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "116-12 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124184",
+    "coordinates": [
+      -73.833513,
+      40.715758
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1494 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120850",
+    "coordinates": [
+      -73.95313791,
+      40.77152635
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1403 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-100200",
+    "coordinates": [
+      -73.946762,
+      40.80007
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1388 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121016",
+    "coordinates": [
+      -73.957499,
+      40.774207
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1380 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-127012",
+    "coordinates": [
+      -73.94987,
+      40.652771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 NEW DORP LANE",
+    "type": "LINK1.0",
+    "id": "si-02-125472",
+    "coordinates": [
+      -74.11408666,
+      40.57285319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3809 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-152798",
+    "coordinates": [
+      -73.9201442,
+      40.8624164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3359 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120365",
+    "coordinates": [
+      -73.95480753,
+      40.82076419
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "134 EAST 149 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-119075",
+    "coordinates": [
+      -73.928165,
+      40.818676
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "835 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-02-133446",
+    "coordinates": [
+      -73.99105603,
+      40.73389175
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120979",
+    "coordinates": [
+      -73.96318025,
+      40.76590165
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3 SLOSSON TERRACE",
+    "type": "LINK5G_Ad",
+    "id": "si-01-125539",
+    "coordinates": [
+      -74.0753967,
+      40.6396002
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1850 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-145960",
+    "coordinates": [
+      -73.94470427,
+      40.82938949
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118-18 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-127841",
+    "coordinates": [
+      -73.8311312,
+      40.69988783
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "66 EAST TREMONT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119599",
+    "coordinates": [
+      -73.9077324,
+      40.8507094
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48-20 SKILLMAN AVENUE",
+    "type": "LINK1.0",
+    "id": "QU-02-124974",
+    "coordinates": [
+      -73.9154447,
+      40.7462024
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "203 BERRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146002",
+    "coordinates": [
+      -73.96128653,
+      40.71643057
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "89-30 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145772",
+    "coordinates": [
+      -73.873658,
+      40.734162
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1340 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-136200",
+    "coordinates": [
+      -73.95618997,
+      40.81366899
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2096 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133413",
+    "coordinates": [
+      -73.981665,
+      40.778381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4058 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120798",
+    "coordinates": [
+      -73.9390856,
+      40.8430336
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "214 WEST 92 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121253",
+    "coordinates": [
+      -73.973425,
+      40.791943
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2246 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120235",
+    "coordinates": [
+      -73.93728907,
+      40.80189861
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2880 BROADWAY",
+    "type": "LINK5G_Ad",
+    "id": "mn-09-120409",
+    "coordinates": [
+      -73.965529,
+      40.8054794
+    ]
+  },
+  {
+    "street_address": "1049 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145861",
+    "coordinates": [
+      -73.955096,
+      40.734684
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "75 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-122841",
+    "coordinates": [
+      -73.98277309,
+      40.7717802
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-20 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-128504",
+    "coordinates": [
+      -73.88498743,
+      40.7474512
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 WEST 26 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-108085",
+    "coordinates": [
+      -73.99167705,
+      40.74484704
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4504 FORT HAMILTON PARKWAY",
+    "type": "LINK5G_Ad",
+    "id": "bk-12-108912",
+    "coordinates": [
+      -73.9950117,
+      40.6402437
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "751 BRUCKNER BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-155725",
+    "coordinates": [
+      -73.89693,
+      40.8145769
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 EAST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-120250",
+    "coordinates": [
+      -73.94142153,
+      40.79864627
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 POWERS STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146050",
+    "coordinates": [
+      -73.95102615,
+      40.71166636
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "233 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133440",
+    "coordinates": [
+      -73.98474973,
+      40.73642647
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 60 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121741",
+    "coordinates": [
+      -73.96580928,
+      40.76210714
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "158 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135231",
+    "coordinates": [
+      -74.00071086,
+      40.74204648
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "868 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-133668",
+    "coordinates": [
+      -73.96760332,
+      40.79802733
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "691 METROPOLITAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-126861",
+    "coordinates": [
+      -73.94594832,
+      40.71444574
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1358 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-121455",
+    "coordinates": [
+      -73.9351479,
+      40.8471969
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "121 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-107697",
+    "coordinates": [
+      -73.98812504,
+      40.72815774
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-1 37 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-146067",
+    "coordinates": [
+      -73.92659983,
+      40.75234817
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1126 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135076",
+    "coordinates": [
+      -73.96062004,
+      40.76126735
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-02 114 STREET",
+    "type": "LINK1.0",
+    "id": "qu-09-145890",
+    "coordinates": [
+      -73.83484675,
+      40.69809542
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "159-29 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-144028",
+    "coordinates": [
+      -73.79934332,
+      40.70376856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "342 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145994",
+    "coordinates": [
+      -73.97183554,
+      40.67613405
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-08 35 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-137830",
+    "coordinates": [
+      -73.92362684,
+      40.75577655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2541 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-118138",
+    "coordinates": [
+      -73.9284509,
+      40.8512652
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1967 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134274",
+    "coordinates": [
+      -73.98239982,
+      40.77464584
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "211 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134912",
+    "coordinates": [
+      -73.9996452,
+      40.74391929
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "63 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121626",
+    "coordinates": [
+      -73.98597197,
+      40.74349317
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "840 WESTCHESTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-119034",
+    "coordinates": [
+      -73.9012951,
+      40.8197086
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2616 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-145933",
+    "coordinates": [
+      -73.89780278,
+      40.86676519
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-69 80 STREET",
+    "type": "LINK1.0",
+    "id": "qu-03-139608",
+    "coordinates": [
+      -73.8857513,
+      40.74760297
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1546 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145759",
+    "coordinates": [
+      -73.93910101,
+      40.67975193
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51-01 GOLDSMITH STREET",
+    "type": "LINK1.0",
+    "id": "qu-04-145776",
+    "coordinates": [
+      -73.880315,
+      40.736982
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "980 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-136666",
+    "coordinates": [
+      -73.96194569,
+      40.80069
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77-01 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-134080",
+    "coordinates": [
+      -73.888492,
+      40.74722343
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2095 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133410",
+    "coordinates": [
+      -73.98198995,
+      40.77933083
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 ALLEN STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-122246",
+    "coordinates": [
+      -73.99248961,
+      40.71450806
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "609 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-135898",
+    "coordinates": [
+      -73.9703352,
+      40.78883163
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "131 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-131017",
+    "coordinates": [
+      -73.98787592,
+      40.72848039
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "790 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122586",
+    "coordinates": [
+      -73.986828,
+      40.761094
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "598 WEST 146 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-134826",
+    "coordinates": [
+      -73.949868,
+      40.826928
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "435 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-136186",
+    "coordinates": [
+      -73.98324818,
+      40.74425922
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 WEST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-123646",
+    "coordinates": [
+      -73.99861909,
+      40.74544348
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "728 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-139998",
+    "coordinates": [
+      -73.99181959,
+      40.76445589
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43 EAST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121973",
+    "coordinates": [
+      -73.97220317,
+      40.76232437
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160 WYCKOFF AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-04-127501",
+    "coordinates": [
+      -73.9164953,
+      40.7025384
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-145917",
+    "coordinates": [
+      -73.92925029,
+      40.81244091
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "22-25 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145746",
+    "coordinates": [
+      -73.94693708,
+      40.74541772
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "614 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134642",
+    "coordinates": [
+      -73.97048243,
+      40.78898616
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2420 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133633",
+    "coordinates": [
+      -73.974793,
+      40.790235
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2538 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-133684",
+    "coordinates": [
+      -73.938202,
+      40.82312447
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3596 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111874",
+    "coordinates": [
+      -73.949017,
+      40.828097
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-31 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145783",
+    "coordinates": [
+      -73.95333647,
+      40.74228717
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "96 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-137879",
+    "coordinates": [
+      -73.99328247,
+      40.73663894
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "776 MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146063",
+    "coordinates": [
+      -73.91484908,
+      40.82211198
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "741 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120527",
+    "coordinates": [
+      -73.9670098,
+      40.7933795
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "112-55 FARMERS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-101876",
+    "coordinates": [
+      -73.763267,
+      40.6999823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "941 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145865",
+    "coordinates": [
+      -74.00440376,
+      40.65413323
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3569 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111986",
+    "coordinates": [
+      -73.95002586,
+      40.82732011
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "760 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133473",
+    "coordinates": [
+      -73.97218,
+      40.754092
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "150 EAST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138051",
+    "coordinates": [
+      -73.97126273,
+      40.75679025
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "132 EAST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-120627",
+    "coordinates": [
+      -73.971614,
+      40.75694469
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "475 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-123120",
+    "coordinates": [
+      -73.99799012,
+      40.73598356
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "219 EAST BURNSIDE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-05-152147",
+    "coordinates": [
+      -73.9026539,
+      40.8520248
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "555 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125915",
+    "coordinates": [
+      -73.989159,
+      40.665618
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2604 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119890",
+    "coordinates": [
+      -73.944659,
+      40.818897
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-40 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124194",
+    "coordinates": [
+      -73.84488371,
+      40.72152582
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "138 WEST 41 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122171",
+    "coordinates": [
+      -73.98635944,
+      40.75485087
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "831 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134444",
+    "coordinates": [
+      -73.99024141,
+      40.74661929
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 GROVE STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123678",
+    "coordinates": [
+      -74.00387699,
+      40.73290856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-124947",
+    "coordinates": [
+      -73.91854,
+      40.742912
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32 EAST 1ST STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-138880",
+    "coordinates": [
+      -73.9906027,
+      40.7243982
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "780 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122651",
+    "coordinates": [
+      -73.982996,
+      40.76164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "83-20 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136365",
+    "coordinates": [
+      -73.88227031,
+      40.74774238
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1329 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120998",
+    "coordinates": [
+      -73.95854022,
+      40.77235777
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "733 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134661",
+    "coordinates": [
+      -73.97360371,
+      40.74812083
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1701 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-135240",
+    "coordinates": [
+      -73.947909,
+      40.824646
+    ]
+  },
+  {
+    "street_address": "968 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125846",
+    "coordinates": [
+      -74.00525819,
+      40.65371111
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "103 SEIGEL STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-145855",
+    "coordinates": [
+      -73.942989,
+      40.704496
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "730 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-139745",
+    "coordinates": [
+      -73.972868,
+      40.753149
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2040 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121335",
+    "coordinates": [
+      -73.98190427,
+      40.77713717
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118-02 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-154850",
+    "coordinates": [
+      -73.7744795,
+      40.6866032
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "733 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-135446",
+    "coordinates": [
+      -73.970376,
+      40.793867
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4306 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120799",
+    "coordinates": [
+      -73.9349028,
+      40.8515612
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "231 EAST 183RD STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-112015",
+    "coordinates": [
+      -73.8992175,
+      40.8572274
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38 UNION SQUARE EAST",
+    "type": "LINK1.0",
+    "id": "mn-05-123155",
+    "coordinates": [
+      -73.989183,
+      40.736141
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40-02 73 STREET",
+    "type": "LINK1.0",
+    "id": "qu-04-136003",
+    "coordinates": [
+      -73.89236832,
+      40.74660883
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 114 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120387",
+    "coordinates": [
+      -73.965108,
+      40.80676
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "28 NORTH 5 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146016",
+    "coordinates": [
+      -73.96276535,
+      40.71906736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2119 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-116230",
+    "coordinates": [
+      -73.940035,
+      40.797709
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "519 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121439",
+    "coordinates": [
+      -73.97836301,
+      40.74159316
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "957 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145812",
+    "coordinates": [
+      -73.96463345,
+      40.68307692
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70 STANTON STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123464",
+    "coordinates": [
+      -73.989421,
+      40.721773
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1187 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-108268",
+    "coordinates": [
+      -73.95971503,
+      40.76292088
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 143 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-120058",
+    "coordinates": [
+      -73.94030397,
+      40.82040617
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1044 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121703",
+    "coordinates": [
+      -73.96291405,
+      40.7581134
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "268 SARATOGA AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-150795",
+    "coordinates": [
+      -73.916601,
+      40.6759851
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "264 WEST 35 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-108471",
+    "coordinates": [
+      -73.99275642,
+      40.75269979
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-20 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125113",
+    "coordinates": [
+      -73.9159581,
+      40.76427257
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36 EAST 84 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121049",
+    "coordinates": [
+      -73.95968089,
+      40.77945381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "206 WEST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-133505",
+    "coordinates": [
+      -73.9830769,
+      40.7625933
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "247 EAST 169 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-146078",
+    "coordinates": [
+      -73.91396042,
+      40.83573444
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "501 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136617",
+    "coordinates": [
+      -73.97893462,
+      40.74122503
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3012 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123215",
+    "coordinates": [
+      -73.913388,
+      40.819568
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110-72 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145762",
+    "coordinates": [
+      -73.838976,
+      40.718953
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "311 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-108348",
+    "coordinates": [
+      -73.99404694,
+      40.68134564
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2013 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-120042",
+    "coordinates": [
+      -73.95009459,
+      40.80624896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "437 PARK PLACE",
+    "type": "LINK1.0",
+    "id": "bk-08-146008",
+    "coordinates": [
+      -73.963553,
+      40.675659
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "117-04 GUY R BREWER BLVD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-138198",
+    "coordinates": [
+      -73.7830247,
+      40.6841092
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2182 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-146076",
+    "coordinates": [
+      -73.93860514,
+      40.80009573
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "354 SARATOGA AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-157161",
+    "coordinates": [
+      -73.9168321,
+      40.6735251
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-25 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-145946",
+    "coordinates": [
+      -73.93415739,
+      40.75149813
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "333 EAST 181 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-119644",
+    "coordinates": [
+      -73.8983647,
+      40.8539699
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-93 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-141148",
+    "coordinates": [
+      -73.9516172,
+      40.74318379
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1481 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120563",
+    "coordinates": [
+      -73.953007,
+      40.817656
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "361 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-146092",
+    "coordinates": [
+      -73.95531649,
+      40.707581
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2882 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-118956",
+    "coordinates": [
+      -73.91648285,
+      40.81667907
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1259 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120952",
+    "coordinates": [
+      -73.95806217,
+      40.76519297
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-33 FOREST PARKWAY",
+    "type": "LINK1.0",
+    "id": "qu-09-124798",
+    "coordinates": [
+      -73.86085811,
+      40.69245106
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "128 MONTAGUE STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126904",
+    "coordinates": [
+      -73.9942271,
+      40.69472554
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "93-01 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-146005",
+    "coordinates": [
+      -73.87355043,
+      40.74879795
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-20 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-145952",
+    "coordinates": [
+      -73.92076317,
+      40.75972324
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "415 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135228",
+    "coordinates": [
+      -73.98061045,
+      40.7385025
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1133 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-126532",
+    "coordinates": [
+      -73.95757439,
+      40.64287503
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 WEST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121257",
+    "coordinates": [
+      -73.9723114,
+      40.78665384
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "52-19 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "QU-02-158449",
+    "coordinates": [
+      -73.912044,
+      40.7426365
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "561 METROPOLITAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145988",
+    "coordinates": [
+      -73.95028299,
+      40.71412964
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "188-01 LINDEN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123887",
+    "coordinates": [
+      -73.7640145,
+      40.6920499
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "656 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145032",
+    "coordinates": [
+      -73.950008,
+      40.675965
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "380 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120493",
+    "coordinates": [
+      -73.95384878,
+      40.81120483
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121767",
+    "coordinates": [
+      -73.96331113,
+      40.76174825
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "266 EAST 205 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-114037",
+    "coordinates": [
+      -73.879019,
+      40.8737327
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "819 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136868",
+    "coordinates": [
+      -73.99050599,
+      40.7462509
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "138-02 NORTHERN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "QU-07-124356",
+    "coordinates": [
+      -73.8279192,
+      40.7638316
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "385 EAST FORDHAM ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119793",
+    "coordinates": [
+      -73.89182996,
+      40.86199332
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "248 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-126514",
+    "coordinates": [
+      -73.97437146,
+      40.67963858
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2939 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120261",
+    "coordinates": [
+      -73.96464555,
+      40.80729581
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2721 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134372",
+    "coordinates": [
+      -73.9682952,
+      40.80009304
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "241 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-140360",
+    "coordinates": [
+      -74.00581555,
+      40.75074558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3900 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120328",
+    "coordinates": [
+      -73.9419026,
+      40.8378335
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4366 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-134406",
+    "coordinates": [
+      -73.9336498,
+      40.8540071
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "168-03 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141536",
+    "coordinates": [
+      -73.792368,
+      40.706507
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "15 EAST 29 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121634",
+    "coordinates": [
+      -73.985367,
+      40.744742
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1678 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145826",
+    "coordinates": [
+      -74.101684,
+      40.589032
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-02 44 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-128387",
+    "coordinates": [
+      -73.9206815,
+      40.74306271
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 WEST 148 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-100231",
+    "coordinates": [
+      -73.94644065,
+      40.82719623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2435 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145730",
+    "coordinates": [
+      -74.10861367,
+      40.57178152
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "123 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123265",
+    "coordinates": [
+      -73.987162,
+      40.733107
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "181 EAST 73 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120990",
+    "coordinates": [
+      -73.960254,
+      40.770545
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 184 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-119628",
+    "coordinates": [
+      -73.89855259,
+      40.85915372
+    ]
+  },
+  {
+    "street_address": "84-43 CORONA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-145898",
+    "coordinates": [
+      -73.87812993,
+      40.73933161
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "166 EAST 56 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121850",
+    "coordinates": [
+      -73.968242,
+      40.75961
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "936 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136181",
+    "coordinates": [
+      -73.968048,
+      40.759756
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "210 EAST 106 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-132877",
+    "coordinates": [
+      -73.94421805,
+      40.7912824
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2883 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123208",
+    "coordinates": [
+      -73.91671907,
+      40.8166923
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "783 BECK STREET",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-144220",
+    "coordinates": [
+      -73.8979885,
+      40.8172651
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30 EAST 64 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121988",
+    "coordinates": [
+      -73.9693177,
+      40.7667374
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "83 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-133516",
+    "coordinates": [
+      -73.98813515,
+      40.73177664
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 WEST 77 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-137179",
+    "coordinates": [
+      -73.9804764,
+      40.78228509
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "695 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127039",
+    "coordinates": [
+      -73.950078,
+      40.673527
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "871 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-107675",
+    "coordinates": [
+      -73.98515741,
+      40.76380275
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1671 BEDFORD AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-155704",
+    "coordinates": [
+      -73.9566925,
+      40.6656564
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1495 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120655",
+    "coordinates": [
+      -73.93218652,
+      40.85162018
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "247 EAST 198 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-119728",
+    "coordinates": [
+      -73.8892133,
+      40.8691842
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "129 EAST 39 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138218",
+    "coordinates": [
+      -73.9771946,
+      40.74950281
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1767 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122522",
+    "coordinates": [
+      -73.98198781,
+      40.76617479
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-03 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-133667",
+    "coordinates": [
+      -73.88464352,
+      40.74762687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "85-05 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136451",
+    "coordinates": [
+      -73.88092373,
+      40.74801962
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1628 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145749",
+    "coordinates": [
+      -73.93549973,
+      40.67956068
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "926 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-127020",
+    "coordinates": [
+      -73.95091335,
+      40.66620283
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145779",
+    "coordinates": [
+      -73.924156,
+      40.743555
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "105-24 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145881",
+    "coordinates": [
+      -73.84118746,
+      40.69522138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "849 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-04-103731",
+    "coordinates": [
+      -73.93844701,
+      40.69887623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "227 CHURCH STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-122911",
+    "coordinates": [
+      -74.00622249,
+      40.71693937
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "720 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-107263",
+    "coordinates": [
+      -73.97088677,
+      40.7935244
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51 EAST 26 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-138316",
+    "coordinates": [
+      -73.98538074,
+      40.74232206
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1391 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121005",
+    "coordinates": [
+      -73.95709,
+      40.77435
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1004 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121778",
+    "coordinates": [
+      -73.96698,
+      40.75678
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "563 ST. ANN'S AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146045",
+    "coordinates": [
+      -73.91295433,
+      40.81447081
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "217 BOWERY",
+    "type": "LINK1.0",
+    "id": "mn-03-108238",
+    "coordinates": [
+      -73.993343,
+      40.721716
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2100 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120466",
+    "coordinates": [
+      -73.9388762,
+      40.8373721
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-50 PARSONS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-141547",
+    "coordinates": [
+      -73.80035218,
+      40.70345249
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101-21 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124792",
+    "coordinates": [
+      -73.845595,
+      40.695205
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1256 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122053",
+    "coordinates": [
+      -73.9881009,
+      40.74813894
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "156 LAWRENCE STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-135003",
+    "coordinates": [
+      -73.98638427,
+      40.69123398
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2079 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-136677",
+    "coordinates": [
+      -73.95698009,
+      40.80234988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "468 BROOK AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146055",
+    "coordinates": [
+      -73.91607435,
+      40.81284091
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "563 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121430",
+    "coordinates": [
+      -73.97730732,
+      40.74303942
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "249 WEST 107 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120402",
+    "coordinates": [
+      -73.967493,
+      40.802126
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2641 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133637",
+    "coordinates": [
+      -73.970011,
+      40.797394
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1670 VICTORY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "si-01-154026",
+    "coordinates": [
+      -74.1192244,
+      40.6131774
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "140 EAST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-133365",
+    "coordinates": [
+      -73.96867055,
+      40.76063098
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3 WEST 44 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122204",
+    "coordinates": [
+      -73.98019325,
+      40.75495251
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163-02 HILLSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-128558",
+    "coordinates": [
+      -73.7991165,
+      40.7086482
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 IRVING PLACE",
+    "type": "LINK1.0",
+    "id": "mn-05-134620",
+    "coordinates": [
+      -73.98873983,
+      40.73414765
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "359 EAST 204 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-119712",
+    "coordinates": [
+      -73.8773562,
+      40.8717955
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 GRAND STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-123346",
+    "coordinates": [
+      -73.9866338,
+      40.716166
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "373 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121498",
+    "coordinates": [
+      -73.98129694,
+      40.74116898
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "66 WEST 21 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-108001",
+    "coordinates": [
+      -73.9935926,
+      40.74150205
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3386 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145941",
+    "coordinates": [
+      -73.87053741,
+      40.68406084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "47-43 VERNON BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-146059",
+    "coordinates": [
+      -73.95348371,
+      40.74432049
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "99-20 189 STREET",
+    "type": "LINK1.0",
+    "id": "qu-12-157659",
+    "coordinates": [
+      -73.7689526,
+      40.7082485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "764 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-111894",
+    "coordinates": [
+      -73.96981,
+      40.795005
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "860 MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-03-118929",
+    "coordinates": [
+      -73.91402994,
+      40.82364629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "413 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122691",
+    "coordinates": [
+      -73.99505137,
+      40.75022678
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "96-05 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124907",
+    "coordinates": [
+      -73.86181,
+      40.7323496
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1349 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120996",
+    "coordinates": [
+      -73.958069,
+      40.773006
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41 SACKMAN STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-145930",
     "coordinates": [
       -73.90590131,
       40.67784547
@@ -14864,23 +4603,1409 @@
     "status": "active"
   },
   {
-    "id": "LINK-022136",
+    "street_address": "376 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121208",
     "coordinates": [
-      -73.94206208,
-      40.65122997
+      -73.97899987,
+      40.78240982
     ],
     "status": "active"
   },
   {
-    "id": "LINK-022137",
+    "street_address": "60 HENRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-125681",
     "coordinates": [
-      -73.94554463,
-      40.65094749
+      -73.99218679,
+      40.69934194
     ],
     "status": "active"
   },
   {
-    "id": "LINK-022138",
+    "street_address": "175 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138573",
+    "coordinates": [
+      -73.98638945,
+      40.73053706
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "92-12 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136655",
+    "coordinates": [
+      -73.87420307,
+      40.74859468
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25 EAST 29 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-123789",
+    "coordinates": [
+      -73.985069,
+      40.744614
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "210 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123500",
+    "coordinates": [
+      -73.99616801,
+      40.74356421
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "826 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136184",
+    "coordinates": [
+      -73.98948974,
+      40.76766312
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "488 BERGEN STREET",
+    "type": "LINK1.0",
+    "id": "bk-08-145919",
+    "coordinates": [
+      -73.97437496,
+      40.68064989
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "165 EAST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-138320",
+    "coordinates": [
+      -73.963554,
+      40.76606
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1525 PITKIN AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-16-158755",
+    "coordinates": [
+      -73.9172669,
+      40.6689013
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "770 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121369",
+    "coordinates": [
+      -73.972507,
+      40.749203
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 WEST 49 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122878",
+    "coordinates": [
+      -73.97792563,
+      40.75795791
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-18 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-125340",
+    "coordinates": [
+      -73.88409786,
+      40.74754337
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-01 ASTORIA BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-146089",
+    "coordinates": [
+      -73.91889468,
+      40.77035989
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133896",
+    "coordinates": [
+      -73.98663439,
+      40.73384075
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1846 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-123186",
+    "coordinates": [
+      -73.91147,
+      40.84873
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "129 EAST 29 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-136968",
+    "coordinates": [
+      -73.981797,
+      40.743229
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 PALMETTO STREET",
+    "type": "LINK1.0",
+    "id": "bk-04-155147",
+    "coordinates": [
+      -73.9154071,
+      40.6950044
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1987 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120233",
+    "coordinates": [
+      -73.943064,
+      40.79357
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "142 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121481",
+    "coordinates": [
+      -73.98203855,
+      40.74338446
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29 EAST 76 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121038",
+    "coordinates": [
+      -73.96372269,
+      40.77449753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "944A INTERVALE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-159084",
+    "coordinates": [
+      -73.896767,
+      40.8213384
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1421 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-142532",
+    "coordinates": [
+      -73.95436371,
+      40.8157996
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "770 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145753",
+    "coordinates": [
+      -73.97022462,
+      40.68454905
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "184 EAST 87 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-119825",
+    "coordinates": [
+      -73.953715,
+      40.779535
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "338 WILSON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-155232",
+    "coordinates": [
+      -73.9171208,
+      40.6956422
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "519 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122068",
+    "coordinates": [
+      -73.9927184,
+      40.75342475
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "204-01 JAMAICA AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123720",
+    "coordinates": [
+      -73.7559382,
+      40.7136082
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 45 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121538",
+    "coordinates": [
+      -73.97065717,
+      40.75163236
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1049 GERARD AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-145687",
+    "coordinates": [
+      -73.92264499,
+      40.831543
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1525 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-107963",
+    "coordinates": [
+      -73.95399,
+      40.7786
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "528 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121512",
+    "coordinates": [
+      -73.97768758,
+      40.74653888
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1284 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135088",
+    "coordinates": [
+      -73.95740873,
+      40.76566545
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1741 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145816",
+    "coordinates": [
+      -73.929834,
+      40.679381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2100 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145824",
+    "coordinates": [
+      -74.11135039,
+      40.58167685
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "897 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-145751",
+    "coordinates": [
+      -73.958801,
+      40.668156
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29 EAST 70 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121152",
+    "coordinates": [
+      -73.96622435,
+      40.77045871
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-09 70 ROAD",
+    "type": "LINK1.0",
+    "id": "qu-06-145961",
+    "coordinates": [
+      -73.84588685,
+      40.72073474
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 EAST 188 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-119570",
+    "coordinates": [
+      -73.89952057,
+      40.86208577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "700 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120611",
+    "coordinates": [
+      -73.97148731,
+      40.79270287
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "709 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-108949",
+    "coordinates": [
+      -73.942908,
+      40.701419
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2620 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-146057",
+    "coordinates": [
+      -73.944183,
+      40.819549
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "465 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135647",
+    "coordinates": [
+      -73.97954419,
+      40.73996264
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1380 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120768",
+    "coordinates": [
+      -73.93451006,
+      40.84808255
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2315 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121306",
+    "coordinates": [
+      -73.977832,
+      40.787028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1088 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145758",
+    "coordinates": [
+      -73.95799026,
+      40.64394086
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "916 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122631",
+    "coordinates": [
+      -73.979721,
+      40.766148
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3632 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-136852",
+    "coordinates": [
+      -73.948046,
+      40.829424
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "183 CHURCH STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-108151",
+    "coordinates": [
+      -74.00718506,
+      40.7157269
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-137940",
+    "coordinates": [
+      -74.00151938,
+      40.71748211
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2922 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-118942",
+    "coordinates": [
+      -73.915574,
+      40.817446
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "340 LIVINGSTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126839",
+    "coordinates": [
+      -73.98128393,
+      40.68781362
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1279 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120767",
+    "coordinates": [
+      -73.93725917,
+      40.84468912
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "764 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-126609",
+    "coordinates": [
+      -73.95745774,
+      40.672302
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-56 111 STREET",
+    "type": "LINK1.0",
+    "id": "qu-09-145878",
+    "coordinates": [
+      -73.837293,
+      40.697047
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2366 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-120001",
+    "coordinates": [
+      -73.95015967,
+      40.81136226
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "95-31 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136366",
+    "coordinates": [
+      -73.87062416,
+      40.7491117
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2939 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-109413",
+    "coordinates": [
+      -73.91526202,
+      40.81792619
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1441 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111670",
+    "coordinates": [
+      -73.93334198,
+      40.85003751
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-134218",
+    "coordinates": [
+      -73.96717705,
+      40.76020693
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2120 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-107218",
+    "coordinates": [
+      -73.94025621,
+      40.79783525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "108-44 SUTPHIN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-124511",
+    "coordinates": [
+      -73.7985019,
+      40.691834
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "155 HERZL STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-158588",
+    "coordinates": [
+      -73.9146879,
+      40.6663218
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "157 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120936",
+    "coordinates": [
+      -73.98094971,
+      40.77426628
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "204-01 HOLLIS AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-156461",
+    "coordinates": [
+      -73.753916,
+      40.7068698
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "660 FLATBUSH AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-126563",
+    "coordinates": [
+      -73.9603383,
+      40.6571638
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23 WEST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-123185",
+    "coordinates": [
+      -73.908662,
+      40.853881
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1007 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-125263",
+    "coordinates": [
+      -73.954886,
+      40.7334
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136396",
+    "coordinates": [
+      -73.99360102,
+      40.73620058
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "402 EASTERN PARKWAY",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-153360",
+    "coordinates": [
+      -73.955285,
+      40.6697913
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98 BOND STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-108355",
+    "coordinates": [
+      -73.98496961,
+      40.68681157
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "501 BRUCKNER BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-02-145581",
+    "coordinates": [
+      -73.9028615,
+      40.8100995
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "293 RALPH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145817",
+    "coordinates": [
+      -73.921802,
+      40.679015
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30 VARICK STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-122285",
+    "coordinates": [
+      -74.0065562,
+      40.72056775
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1170 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-139806",
+    "coordinates": [
+      -73.98867089,
+      40.74512705
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48 WEST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119610",
+    "coordinates": [
+      -73.90938798,
+      40.85384203
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "715 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122583",
+    "coordinates": [
+      -73.98857946,
+      40.75910666
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "971 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145907",
+    "coordinates": [
+      -73.95805063,
+      40.64788737
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-138618",
+    "coordinates": [
+      -74.00808439,
+      40.72340371
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "572 WEST 207 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120711",
+    "coordinates": [
+      -73.9206195,
+      40.8665829
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "20 EAST 60 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-135983",
+    "coordinates": [
+      -73.970823,
+      40.764097
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "615 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122075",
+    "coordinates": [
+      -73.99093285,
+      40.75587809
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "75 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-123540",
+    "coordinates": [
+      -74.00273531,
+      40.73967748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "26 EAST 33 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121651",
+    "coordinates": [
+      -73.983698,
+      40.747144
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "408 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136910",
+    "coordinates": [
+      -73.994993,
+      40.74988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36 BOND STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-142293",
+    "coordinates": [
+      -73.98371008,
+      40.6886723
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2737 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134423",
+    "coordinates": [
+      -73.96818631,
+      40.80047593
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "875 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145901",
+    "coordinates": [
+      -74.002053,
+      40.656384
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "734 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120609",
+    "coordinates": [
+      -73.97057117,
+      40.79396219
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "105 WEST 106 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107744",
+    "coordinates": [
+      -73.9631832,
+      40.79947246
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "795 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-107739",
+    "coordinates": [
+      -73.99100163,
+      40.74557814
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1604 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122088",
+    "coordinates": [
+      -73.98446631,
+      40.76064069
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2199 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-138145",
+    "coordinates": [
+      -73.98070878,
+      40.78312136
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1360 EAST BAY AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-145582",
+    "coordinates": [
+      -73.8820819,
+      40.8089271
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "187-07 HENDERSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-154544",
+    "coordinates": [
+      -73.7705256,
+      40.7079873
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 150 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120355",
+    "coordinates": [
+      -73.94842204,
+      40.82966242
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "83-02 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-145914",
+    "coordinates": [
+      -73.87992485,
+      40.74093675
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4980 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120833",
+    "coordinates": [
+      -73.9192674,
+      40.8681406
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2110 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145733",
+    "coordinates": [
+      -74.11201028,
+      40.581304
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29-37 40 ROAD",
+    "type": "LINK1.0",
+    "id": "qu-01-145958",
+    "coordinates": [
+      -73.93494274,
+      40.75114906
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "888 PACIFIC STREET",
+    "type": "LINK1.0",
+    "id": "bk-08-145908",
+    "coordinates": [
+      -73.96451072,
+      40.68023805
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "994 EAST 163 STREET",
+    "type": "LINK1.0",
+    "id": "bx-02-108937",
+    "coordinates": [
+      -73.8940408,
+      40.8208896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "748 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134602",
+    "coordinates": [
+      -73.97005104,
+      40.79467259
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "347 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-122259",
+    "coordinates": [
+      -74.00119407,
+      40.73188717
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1805 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-127093",
+    "coordinates": [
+      -73.925474,
+      40.679143
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "19 SEAVIEW AVENUE",
+    "type": "LINK1.0",
+    "id": "si-02-125476",
+    "coordinates": [
+      -74.100732,
+      40.590983
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "215 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133659",
+    "coordinates": [
+      -73.9799974,
+      40.74559121
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-21 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125086",
+    "coordinates": [
+      -73.92387,
+      40.761341
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40-13 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-145452",
+    "coordinates": [
+      -73.91849412,
+      40.75881765
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "555 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134597",
+    "coordinates": [
+      -73.99629565,
+      40.7383024
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "92-03 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136703",
+    "coordinates": [
+      -73.87439289,
+      40.74870842
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145-50 LIBERTY AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-158761",
+    "coordinates": [
+      -73.8069082,
+      40.694038
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "129-21 MERRICK BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-118523",
+    "coordinates": [
+      -73.7633582,
+      40.6806786
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2277 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-143437",
+    "coordinates": [
+      -73.93627,
+      40.80287
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "325 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-123801",
+    "coordinates": [
+      -73.98380229,
+      40.73195957
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-35 33 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-125042",
+    "coordinates": [
+      -73.92939864,
+      40.75418823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23 EAST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121959",
+    "coordinates": [
+      -73.97534075,
+      40.75863294
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "521 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133470",
+    "coordinates": [
+      -73.977614,
+      40.746217
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "975 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-107980",
+    "coordinates": [
+      -73.96189127,
+      40.80040455
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2498 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133625",
+    "coordinates": [
+      -73.97312473,
+      40.79253447
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "442 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-144892",
+    "coordinates": [
+      -73.91949122,
+      40.81357503
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1518 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121017",
+    "coordinates": [
+      -73.954541,
+      40.778272
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82-10 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-142872",
+    "coordinates": [
+      -73.88093968,
+      40.73720596
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "401 West 203rd Street",
+    "type": "LINK1.0",
+    "id": "mn-12-150314",
+    "coordinates": [
+      -73.9190889,
+      40.8612787
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "450 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-135179",
+    "coordinates": [
+      -73.9905922,
+      40.75122432
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 46 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121370",
+    "coordinates": [
+      -73.972445,
+      40.753196
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2300 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121235",
+    "coordinates": [
+      -73.97776529,
+      40.78651948
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "278 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-134089",
+    "coordinates": [
+      -73.98705217,
+      40.73946433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "314 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-138822",
+    "coordinates": [
+      -74.003811,
+      40.753067
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "476 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134832",
+    "coordinates": [
+      -73.97904816,
+      40.74023291
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "688 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122270",
+    "coordinates": [
+      -73.99326129,
+      40.74208082
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "625 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-145539",
+    "coordinates": [
+      -73.97007535,
+      40.78918247
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1043 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121780",
+    "coordinates": [
+      -73.96642136,
+      40.7579749
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 EAST 29 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121570",
+    "coordinates": [
+      -73.98337004,
+      40.74389121
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "953 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121857",
+    "coordinates": [
+      -73.96730567,
+      40.76034713
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121360",
+    "coordinates": [
+      -73.97518642,
+      40.74934112
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1780 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-136457",
+    "coordinates": [
+      -73.94622593,
+      40.82730494
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1644 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119832",
+    "coordinates": [
+      -73.95125729,
+      40.78276562
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2534 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-134720",
+    "coordinates": [
+      -73.93836455,
+      40.82290225
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "8 WEST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-122843",
+    "coordinates": [
+      -73.98184115,
+      40.76956574
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3121 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-145927",
     "coordinates": [
       -73.947834,
       40.650962
@@ -14888,15 +6013,6262 @@
     "status": "active"
   },
   {
-    "id": "LINK-022140",
+    "street_address": "1591 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-126509",
     "coordinates": [
-      -73.952414,
-      40.648733
+      -73.94678067,
+      40.63213478
     ],
     "status": "active"
   },
   {
-    "id": "LINK-022141",
+    "street_address": "400 EAST 50 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-137127",
+    "coordinates": [
+      -73.96597025,
+      40.75375106
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 WEST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122858",
+    "coordinates": [
+      -73.97425395,
+      40.76298745
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 MORRIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146046",
+    "coordinates": [
+      -73.92624362,
+      40.81255748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "166 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-120049",
+    "coordinates": [
+      -73.94812464,
+      40.80879309
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "240 WEST 102 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120273",
+    "coordinates": [
+      -73.96927886,
+      40.798538
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 MONTROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145892",
+    "coordinates": [
+      -73.943399,
+      40.707379
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1941 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120463",
+    "coordinates": [
+      -73.942327,
+      40.832283
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "175 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146006",
+    "coordinates": [
+      -73.9610955,
+      40.71449771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2182 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121221",
+    "coordinates": [
+      -73.98058629,
+      40.78252808
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "150 EAST 4 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123294",
+    "coordinates": [
+      -73.98703948,
+      40.72500355
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "168 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125930",
+    "coordinates": [
+      -73.97973799,
+      40.67761961
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2868 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134377",
+    "coordinates": [
+      -73.9659025,
+      40.80495915
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-02 ASTORIA BOULEVARD SOUTH",
+    "type": "LINK1.0",
+    "id": "qu-01-125165",
+    "coordinates": [
+      -73.912837,
+      40.76909552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "7 WEST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122200",
+    "coordinates": [
+      -73.97825829,
+      40.7574068
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "74 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-128511",
+    "coordinates": [
+      -74.00259998,
+      40.73944747
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "845 RIVERSIDE DRIVE",
+    "type": "LINK1.0",
+    "id": "mn-12-120345",
+    "coordinates": [
+      -73.9474466,
+      40.8360182
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "995 WESTCHESTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-157103",
+    "coordinates": [
+      -73.8939601,
+      40.8238585
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3560 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120436",
+    "coordinates": [
+      -73.949738,
+      40.827117
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3923 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-126292",
+    "coordinates": [
+      -73.940166,
+      40.651341
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "605 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126565",
+    "coordinates": [
+      -73.980613,
+      40.688851
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2461 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-116218",
+    "coordinates": [
+      -73.89305944,
+      40.86021467
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "620 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125917",
+    "coordinates": [
+      -73.99124562,
+      40.66355007
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "96 EAST 170 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119157",
+    "coordinates": [
+      -73.915848,
+      40.839445
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "232 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123501",
+    "coordinates": [
+      -73.998993,
+      40.744403
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "5 ST. JAMES PLACE",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-137407",
+    "coordinates": [
+      -74.0003838,
+      40.7109549
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2454 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119573",
+    "coordinates": [
+      -73.90031404,
+      40.86231329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-01 42 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-145743",
+    "coordinates": [
+      -73.92240124,
+      40.74331229
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2057 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-126635",
+    "coordinates": [
+      -73.911008,
+      40.678354
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "21 EAST 31 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121632",
+    "coordinates": [
+      -73.98449219,
+      40.74598598
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "119 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145856",
+    "coordinates": [
+      -73.94303,
+      40.705768
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1882 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120226",
+    "coordinates": [
+      -73.945683,
+      40.790401
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "170 EAST 69 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120985",
+    "coordinates": [
+      -73.96225464,
+      40.76785489
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "471 WILSON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-159465",
+    "coordinates": [
+      -73.9118924,
+      40.6928989
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160-12 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141542",
+    "coordinates": [
+      -73.79847028,
+      40.7039284
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "739 UNION STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-127417",
+    "coordinates": [
+      -73.98029,
+      40.676409
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "132 WEST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122166",
+    "coordinates": [
+      -73.986581,
+      40.754144
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "175 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135811",
+    "coordinates": [
+      -73.99683036,
+      40.74230081
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "7 NASSAU AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145998",
+    "coordinates": [
+      -73.95468869,
+      40.72253263
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2477 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121298",
+    "coordinates": [
+      -73.973761,
+      40.792255
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "146-02 91 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-124575",
+    "coordinates": [
+      -73.8087829,
+      40.7009333
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77-20 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-124926",
+    "coordinates": [
+      -73.88571747,
+      40.73810857
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2109 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119980",
+    "coordinates": [
+      -73.95648813,
+      40.80302425
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "322 LIVINGSTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145811",
+    "coordinates": [
+      -73.98187215,
+      40.68803876
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1475 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-134740",
+    "coordinates": [
+      -73.95513841,
+      40.77703019
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-135892",
+    "coordinates": [
+      -73.9795852,
+      40.75254482
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "426 EAST TREMONT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-119390",
+    "coordinates": [
+      -73.89994835,
+      40.84740591
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "113-14 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145790",
+    "coordinates": [
+      -73.83549622,
+      40.71721235
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "795 WASHINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-146009",
+    "coordinates": [
+      -73.962694,
+      40.672748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "266 WEST 58 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122628",
+    "coordinates": [
+      -73.982247,
+      40.767271
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "62 EAST 13 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-133831",
+    "coordinates": [
+      -73.991208,
+      40.734036
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3177 WEBSTER AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-07-119724",
+    "coordinates": [
+      -73.875333,
+      40.8727297
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160 EAST 50 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121820",
+    "coordinates": [
+      -73.97102968,
+      40.75587721
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "621 RUTLAND ROAD",
+    "type": "LINK1.0",
+    "id": "bk-09-155198",
+    "coordinates": [
+      -73.939963,
+      40.6601033
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48-15 11 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-145795",
+    "coordinates": [
+      -73.95080577,
+      40.74338234
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1413 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-100223",
+    "coordinates": [
+      -73.94648352,
+      40.800446
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "825 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145866",
+    "coordinates": [
+      -74.000689,
+      40.657704
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "250 BROOK AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146075",
+    "coordinates": [
+      -73.91900611,
+      40.80775593
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "166 EAST 67 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120978",
+    "coordinates": [
+      -73.96313599,
+      40.76658802
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "185 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126166",
+    "coordinates": [
+      -73.99314691,
+      40.6879008
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "112-28 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124182",
+    "coordinates": [
+      -73.836262,
+      40.717664
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-136018",
+    "coordinates": [
+      -73.98924679,
+      40.7306716
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-55 KEW GARDENS ROAD",
+    "type": "LINK1.0",
+    "id": "qu-09-128371",
+    "coordinates": [
+      -73.82980897,
+      40.71316697
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 WEST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-133359",
+    "coordinates": [
+      -73.984342,
+      40.759971
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 56 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122649",
+    "coordinates": [
+      -73.98073089,
+      40.76487454
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 WEST 138 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-119949",
+    "coordinates": [
+      -73.94252463,
+      40.81738064
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51 EAST TREMONT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119598",
+    "coordinates": [
+      -73.908266,
+      40.851329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "66 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145910",
+    "coordinates": [
+      -73.9887287,
+      40.68940822
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "436 BROOK AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-131467",
+    "coordinates": [
+      -73.91646687,
+      40.81216272
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "234 WEST 104 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120392",
+    "coordinates": [
+      -73.96796962,
+      40.7996299
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "102-01 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-108791",
+    "coordinates": [
+      -73.845226,
+      40.695225
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77-06 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-132440",
+    "coordinates": [
+      -73.886253,
+      40.738208
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77 WEST 85 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-134114",
+    "coordinates": [
+      -73.97246279,
+      40.78577388
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "560 WEST 42 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-122406",
+    "coordinates": [
+      -73.99820283,
+      40.76065999
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1516 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120665",
+    "coordinates": [
+      -73.93145198,
+      40.85225684
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3670 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111931",
+    "coordinates": [
+      -73.947195,
+      40.830586
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 VICTORY BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-01-145551",
+    "coordinates": [
+      -74.0771009,
+      40.637984
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38-18 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-143422",
+    "coordinates": [
+      -73.926455,
+      40.743823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2126 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120240",
+    "coordinates": [
+      -73.94003626,
+      40.79813946
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "193 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-115305",
+    "coordinates": [
+      -73.98592802,
+      40.73115701
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "55 WATER STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-136177",
+    "coordinates": [
+      -74.00908241,
+      40.7039098
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "383 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122445",
+    "coordinates": [
+      -73.99180123,
+      40.74915253
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "322 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133687",
+    "coordinates": [
+      -73.99336333,
+      40.74741879
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70 WEST 71 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107864",
+    "coordinates": [
+      -73.97905068,
+      40.77657343
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2110 GRAND CONCOURSE",
+    "type": "LINK5G_Ad",
+    "id": "bx-05-153077",
+    "coordinates": [
+      -73.9015385,
+      40.8544689
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23-03 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145792",
+    "coordinates": [
+      -73.94524605,
+      40.74608863
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41-19 31 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146036",
+    "coordinates": [
+      -73.91557,
+      40.760686
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "319 EAST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119802",
+    "coordinates": [
+      -73.8938944,
+      40.86234731
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121157",
+    "coordinates": [
+      -73.97785338,
+      40.77888904
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1622 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111868",
+    "coordinates": [
+      -73.9289967,
+      40.85561537
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "378 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134559",
+    "coordinates": [
+      -73.98133262,
+      40.74153614
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 49 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121792",
+    "coordinates": [
+      -73.968836,
+      40.754138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "831 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-142000",
+    "coordinates": [
+      -73.98615577,
+      40.76243064
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "911 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122616",
+    "coordinates": [
+      -73.98433343,
+      40.76493291
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "836 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120536",
+    "coordinates": [
+      -73.96822346,
+      40.79717824
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "351 EAST 60 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121708",
+    "coordinates": [
+      -73.96166314,
+      40.76035998
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118 VARICK STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123586",
+    "coordinates": [
+      -74.00579536,
+      40.72492489
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "650 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-137977",
+    "coordinates": [
+      -73.97488777,
+      40.75037797
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2495 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133635",
+    "coordinates": [
+      -73.97343761,
+      40.79269555
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2266 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-142952",
+    "coordinates": [
+      -73.93673443,
+      40.8026609
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "34 EAST 73 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121031",
+    "coordinates": [
+      -73.96483887,
+      40.77237316
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2321 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133810",
+    "coordinates": [
+      -73.97764565,
+      40.78724687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "699 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134489",
+    "coordinates": [
+      -73.99320916,
+      40.74254842
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "202 EAST 188 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-145959",
+    "coordinates": [
+      -73.8974,
+      40.86115
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125105",
+    "coordinates": [
+      -73.91093862,
+      40.76191296
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-37 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-145897",
+    "coordinates": [
+      -73.8829233,
+      40.74302376
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "870 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122609",
+    "coordinates": [
+      -73.98498723,
+      40.76361577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2969 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123214",
+    "coordinates": [
+      -73.91461401256561,
+      40.81850954098598
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 WEST 145 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-120062",
+    "coordinates": [
+      -73.939286,
+      40.821828
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "470 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121448",
+    "coordinates": [
+      -73.97932655,
+      40.73985154
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1011 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121695",
+    "coordinates": [
+      -73.96390551,
+      40.75717377
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "18 BELMONT AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-16-153189",
+    "coordinates": [
+      -73.9096658,
+      40.6684808
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "634 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145990",
+    "coordinates": [
+      -73.955858,
+      40.676714
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "140 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135857",
+    "coordinates": [
+      -73.98688143,
+      40.73391885
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "22 EAST 65 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121137",
+    "coordinates": [
+      -73.968865,
+      40.767364
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "21 EAST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120942",
+    "coordinates": [
+      -73.968364,
+      40.768093
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1585 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119822",
+    "coordinates": [
+      -73.9524,
+      40.780782
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98-22 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145767",
+    "coordinates": [
+      -73.85744565,
+      40.72806732
+    ]
+  },
+  {
+    "street_address": "45 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-123431",
+    "coordinates": [
+      -74.00257,
+      40.716033
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2327 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142632",
+    "coordinates": [
+      -73.95141341,
+      40.81002334
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "126 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-137007",
+    "coordinates": [
+      -74.00137,
+      40.741123
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "35 ST. MARKS PLACE",
+    "type": "LINK1.0",
+    "id": "mn-03-108511",
+    "coordinates": [
+      -73.98791444,
+      40.72875565
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123521",
+    "coordinates": [
+      -74.00436342,
+      40.74212485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "205 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134810",
+    "coordinates": [
+      -73.98037405,
+      40.7450706
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121264",
+    "coordinates": [
+      -73.97313741,
+      40.7853501
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2534 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119881",
+    "coordinates": [
+      -73.94655805,
+      40.81629802
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145888",
+    "coordinates": [
+      -73.83784205,
+      40.69633127
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "766 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-123642",
+    "coordinates": [
+      -73.991375,
+      40.744668
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "245 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138570",
+    "coordinates": [
+      -73.97332638,
+      40.74867273
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "47-16 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-140339",
+    "coordinates": [
+      -73.91297466,
+      40.75607269
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2115 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145809",
+    "coordinates": [
+      -74.101669,
+      40.578802
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10 WEST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-133518",
+    "coordinates": [
+      -73.98250198,
+      40.76983868
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82-01 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-125359",
+    "coordinates": [
+      -73.88415453,
+      40.74982932
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33-20 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145934",
+    "coordinates": [
+      -73.919173,
+      40.76578525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2206 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133397",
+    "coordinates": [
+      -73.980123,
+      40.783373
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "548 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-119011",
+    "coordinates": [
+      -73.9176574,
+      40.80681954
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "233 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-108002",
+    "coordinates": [
+      -73.99915958,
+      40.74458405
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "945 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-109579",
+    "coordinates": [
+      -73.96855237,
+      40.75504319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1356 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-146082",
+    "coordinates": [
+      -73.95586492,
+      40.81410283
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "21-04 NEWTOWN AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146087",
+    "coordinates": [
+      -73.92577772,
+      40.77203314
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1063 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121770",
+    "coordinates": [
+      -73.9658397,
+      40.75877707
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "123-23 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-115253",
+    "coordinates": [
+      -73.82655102,
+      40.70086445
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-23 GREENPOINT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-124987",
+    "coordinates": [
+      -73.91899505,
+      40.74221127
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125912",
+    "coordinates": [
+      -73.987979,
+      40.667305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123814",
+    "coordinates": [
+      -73.987965,
+      40.728027
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2163 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-136444",
+    "coordinates": [
+      -73.981184,
+      40.781984
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "176 EAST 71 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120994",
+    "coordinates": [
+      -73.96132436,
+      40.76910162
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "936 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-137023",
+    "coordinates": [
+      -73.96540561,
+      40.75469528
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "205 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133527",
+    "coordinates": [
+      -73.9849,
+      40.736214
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "585 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136296",
+    "coordinates": [
+      -73.97684323,
+      40.74365854
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-15 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-133287",
+    "coordinates": [
+      -73.857547,
+      40.692672
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2310 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121247",
+    "coordinates": [
+      -73.97748309,
+      40.78689604
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-52 100 STREET",
+    "type": "LINK1.0",
+    "id": "qu-03-125430",
+    "coordinates": [
+      -73.86858881,
+      40.75748463
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "655 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135464",
+    "coordinates": [
+      -73.9939631,
+      40.74151493
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "395 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121496",
+    "coordinates": [
+      -73.98068,
+      40.742007
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "271 EAST 161 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119077",
+    "coordinates": [
+      -73.91825809,
+      40.82560474
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1781 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120573",
+    "coordinates": [
+      -73.946043,
+      40.827195
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "268 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-126207",
+    "coordinates": [
+      -73.95918257,
+      40.70877985
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2491 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-138120",
+    "coordinates": [
+      -73.94750336,
+      40.81537577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "238 EAST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-134746",
+    "coordinates": [
+      -73.9525944,
+      40.77814082
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "438 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134920",
+    "coordinates": [
+      -73.97990736,
+      40.74349362
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "875 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125841",
+    "coordinates": [
+      -74.002446,
+      40.656011
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2017 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120457",
+    "coordinates": [
+      -73.94047731,
+      40.83481514
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2527 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119880",
+    "coordinates": [
+      -73.94654809,
+      40.81668892
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 EAST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121680",
+    "coordinates": [
+      -73.96565023,
+      40.75437122
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "700 SOUTHERN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-153487",
+    "coordinates": [
+      -73.8988457,
+      40.8134356
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "76-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "QU-03-152939",
+    "coordinates": [
+      -73.8908315,
+      40.7546986
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "153 NORTH 8 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146073",
+    "coordinates": [
+      -73.95723131,
+      40.71851349
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "643 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-138318",
+    "coordinates": [
+      -73.97544551,
+      40.74559596
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1398 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-135041",
+    "coordinates": [
+      -73.934241,
+      40.84844385
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "624 MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146062",
+    "coordinates": [
+      -73.91679096,
+      40.81801655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145872",
+    "coordinates": [
+      -73.97846492,
+      40.67950101
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "170 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123269",
+    "coordinates": [
+      -73.986348,
+      40.730249
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "62 PENNSYLVANIA AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-05-145932",
+    "coordinates": [
+      -73.89716745,
+      40.67647467
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "592 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-123137",
+    "coordinates": [
+      -73.99526424,
+      40.73933558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "410 EAST 6 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123797",
+    "coordinates": [
+      -73.98610433,
+      40.72630382
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-01 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-133970",
+    "coordinates": [
+      -73.92211147,
+      40.76730678
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 EAST 33 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121613",
+    "coordinates": [
+      -73.98483344,
+      40.74773664
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "111 EAST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-111577",
+    "coordinates": [
+      -73.905076,
+      40.853028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "511 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136697",
+    "coordinates": [
+      -73.97327607,
+      40.7550884
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "60 EAST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-145689",
+    "coordinates": [
+      -73.89565372,
+      40.86658827
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "525 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121513",
+    "coordinates": [
+      -73.977444,
+      40.746449
+    ]
+  },
+  {
+    "street_address": "362 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122680",
+    "coordinates": [
+      -73.996012,
+      40.748482
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "26 EAST 84 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121048",
+    "coordinates": [
+      -73.9599541,
+      40.77956091
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1473 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145757",
+    "coordinates": [
+      -73.94226,
+      40.680059
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "349 EAST 149 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-123228",
+    "coordinates": [
+      -73.919637,
+      40.816692
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-120039",
+    "coordinates": [
+      -73.948011,
+      40.808939
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "105 EAST 198 STREET",
+    "type": "LINK5G_Ad",
+    "id": "bx-07-100074",
+    "coordinates": [
+      -73.8916481,
+      40.8706129
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "547 ROGERS AVEENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-157710",
+    "coordinates": [
+      -73.9532405,
+      40.6586395
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "502 WEST 136 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120561",
+    "coordinates": [
+      -73.951942,
+      40.8196
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1480 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120657",
+    "coordinates": [
+      -73.93224896,
+      40.8511646
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 45 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-133536",
+    "coordinates": [
+      -73.985832,
+      40.758022
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2121 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-136462",
+    "coordinates": [
+      -73.98157091,
+      40.78081899
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "230 WEST 95 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107918",
+    "coordinates": [
+      -73.97203479,
+      40.79382166
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "251 EAST 49 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121794",
+    "coordinates": [
+      -73.9691842,
+      40.75439185
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "230 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134583",
+    "coordinates": [
+      -73.98469437,
+      40.73251879
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "166-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-138109",
+    "coordinates": [
+      -73.79365361,
+      40.70584719
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29 BEDFORD PARK BOULEVARD EAST",
+    "type": "LINK1.0",
+    "id": "bx-07-119754",
+    "coordinates": [
+      -73.8885411,
+      40.8730101
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1200 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120945",
+    "coordinates": [
+      -73.95920163,
+      40.76321777
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "72 WYCKOFF AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-04-127500",
+    "coordinates": [
+      -73.9201547,
+      40.7048216
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "85-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124799",
+    "coordinates": [
+      -73.858948,
+      40.692466
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-15 70 ROAD",
+    "type": "LINK1.0",
+    "id": "qu-06-145955",
+    "coordinates": [
+      -73.84560657,
+      40.72117684
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "658 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145991",
+    "coordinates": [
+      -73.95621158,
+      40.67574507
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4139 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-116022",
+    "coordinates": [
+      -73.9385979,
+      40.8461168
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145841",
+    "coordinates": [
+      -73.92988537,
+      40.81503931
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2794 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134069",
+    "coordinates": [
+      -73.967461,
+      40.802736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "458 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-137863",
+    "coordinates": [
+      -73.99036533,
+      40.75153962
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "210 LIVINGSTON STREET",
+    "type": "LINK5G_Ad",
+    "id": "BK-02-126850",
+    "coordinates": [
+      -73.985594,
+      40.689497
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "284 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123595",
+    "coordinates": [
+      -74.00755377,
+      40.72533498
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "281 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-140298",
+    "coordinates": [
+      -74.00475581,
+      40.75219823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2800 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-120401",
+    "coordinates": [
+      -73.9673706,
+      40.8029572
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25-14 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125095",
+    "coordinates": [
+      -73.92793528,
+      40.7630995
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "776 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-141113",
+    "coordinates": [
+      -73.99898564,
+      40.65974544
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3581 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111985",
+    "coordinates": [
+      -73.949581,
+      40.827932
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "221 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-122289",
+    "coordinates": [
+      -74.007972,
+      40.724065
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "703 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122466",
+    "coordinates": [
+      -73.99286971,
+      40.76338512
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "745 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134283",
+    "coordinates": [
+      -73.9835375,
+      40.76052662
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "933 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122625",
+    "coordinates": [
+      -73.98384519,
+      40.76560072
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "479 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134374",
+    "coordinates": [
+      -73.9792518,
+      40.74036856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2415 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-117868",
+    "coordinates": [
+      -73.90196472,
+      40.86176218
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1330 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-134742",
+    "coordinates": [
+      -73.95876684,
+      40.7724771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2154 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-125467",
+    "coordinates": [
+      -74.10231,
+      40.577771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "242 EAST 10 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-139455",
+    "coordinates": [
+      -73.98468,
+      40.728824
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1131 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121764",
+    "coordinates": [
+      -73.96418067,
+      40.76104904
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "106-17 153rd STREET",
+    "type": "LINK1.0",
+    "id": "qu-12-155917",
+    "coordinates": [
+      -73.8003953,
+      40.6958716
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "125 WORTH STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-137399",
+    "coordinates": [
+      -74.00266673,
+      40.71548409
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-58 45 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-146051",
+    "coordinates": [
+      -73.950086,
+      40.747793
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "218 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138879",
+    "coordinates": [
+      -73.98513107,
+      40.73192289
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2640 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-137208",
+    "coordinates": [
+      -73.94377622,
+      40.8201217
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4180 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120792",
+    "coordinates": [
+      -73.9377808,
+      40.8478703
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2663 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-119760",
+    "coordinates": [
+      -73.89764488,
+      40.86737055
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "112-04 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145786",
+    "coordinates": [
+      -73.83680527,
+      40.71796031
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51-30 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-125075",
+    "coordinates": [
+      -73.90745354,
+      40.75313917
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-01 31 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146040",
+    "coordinates": [
+      -73.922478,
+      40.763931
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121203",
+    "coordinates": [
+      -73.982777,
+      40.777227
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1660 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-146098",
+    "coordinates": [
+      -74.10127071,
+      40.58948831
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "153-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-142734",
+    "coordinates": [
+      -73.80201889,
+      40.70273351
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1550 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-138052",
+    "coordinates": [
+      -73.953537,
+      40.779635
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1066 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121769",
+    "coordinates": [
+      -73.96558891,
+      40.75868871
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "674 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121100",
+    "coordinates": [
+      -73.97197865,
+      40.7920348
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "72 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123260",
+    "coordinates": [
+      -73.989248,
+      40.726263
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1177 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145522",
+    "coordinates": [
+      -74.08262136,
+      40.59839673
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "73-02 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-134075",
+    "coordinates": [
+      -73.89214477,
+      40.74671112
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1988 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-100263",
+    "coordinates": [
+      -73.94144661,
+      40.83386084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2240 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120199",
+    "coordinates": [
+      -73.93810732,
+      40.79636046
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "825 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122595",
+    "coordinates": [
+      -73.98629301,
+      40.76224616
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "949 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121849",
+    "coordinates": [
+      -73.96782751,
+      40.75963164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "539 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121442",
+    "coordinates": [
+      -73.97789516,
+      40.74223411
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2704 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-107810",
+    "coordinates": [
+      -73.96823224,
+      40.79933067
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "18 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123542",
+    "coordinates": [
+      -73.994742,
+      40.736387
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125118",
+    "coordinates": [
+      -73.91254129,
+      40.76266328
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "590 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127044",
+    "coordinates": [
+      -73.94979845,
+      40.67826808
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 WEST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-133373",
+    "coordinates": [
+      -73.98315529,
+      40.76693979
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "71 WYCKOFF STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145904",
+    "coordinates": [
+      -73.991014,
+      40.686177
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "228 EAST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-128743",
+    "coordinates": [
+      -73.95282089,
+      40.77823256
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-133491",
+    "coordinates": [
+      -73.989008,
+      40.730578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1701 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122541",
+    "coordinates": [
+      -73.98262883,
+      40.76397808
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "58-28 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145744",
+    "coordinates": [
+      -73.906524,
+      40.741506
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "852 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-136087",
+    "coordinates": [
+      -73.96784046,
+      40.79770007
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "540 SOUTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-02-157674",
+    "coordinates": [
+      -73.9038634,
+      40.812112
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "279 EAST 44 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-136611",
+    "coordinates": [
+      -73.9715336,
+      40.75129568
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 WEST 42 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-107752",
+    "coordinates": [
+      -73.99301581,
+      40.75848241
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "42-27 35 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145950",
+    "coordinates": [
+      -73.91981871,
+      40.75413552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2120 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133408",
+    "coordinates": [
+      -73.98131051,
+      40.78032124
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "676 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121536",
+    "coordinates": [
+      -73.97414247,
+      40.75140578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "99 WEST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-138528",
+    "coordinates": [
+      -73.9492591,
+      40.80194888
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "345 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134971",
+    "coordinates": [
+      -73.98229109,
+      40.73616484
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "151 EAST 31 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121505",
+    "coordinates": [
+      -73.97965465,
+      40.74395034
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "265 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-123541",
+    "coordinates": [
+      -74.00221656,
+      40.73971856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "55 WATER STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-123002",
+    "coordinates": [
+      -74.00998457,
+      40.70331108
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "975 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-102695",
+    "coordinates": [
+      -73.9647473,
+      40.8015795
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "601 WEST 135 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120374",
+    "coordinates": [
+      -73.95526804,
+      40.82027959
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "111 WEST 68 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121337",
+    "coordinates": [
+      -73.98182879,
+      40.77539028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "472 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134272",
+    "coordinates": [
+      -73.97381614,
+      40.78442334
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3642 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-102722",
+    "coordinates": [
+      -73.947866,
+      40.829675
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "306 WEST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-136625",
+    "coordinates": [
+      -73.98344153,
+      40.76686129
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1381 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-145978",
+    "coordinates": [
+      -73.95528026,
+      40.81453869
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2550 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119879",
+    "coordinates": [
+      -73.94601241,
+      40.81705699
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1626 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-111918",
+    "coordinates": [
+      -73.9499056,
+      40.82226783
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "183 EAST 78 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121004",
+    "coordinates": [
+      -73.957965,
+      40.773727
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2298 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133415",
+    "coordinates": [
+      -73.97799347,
+      40.78622273
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-51 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145782",
+    "coordinates": [
+      -73.95267766,
+      40.74263091
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80 WEST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121256",
+    "coordinates": [
+      -73.97205515,
+      40.78633453
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "392 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-138042",
+    "coordinates": [
+      -73.980968,
+      40.737627
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 WEST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-108148",
+    "coordinates": [
+      -73.98725149,
+      40.76107343
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3779 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120348",
+    "coordinates": [
+      -73.94544961,
+      40.83418925
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82-37 KEW GARDENS ROAD",
+    "type": "LINK1.0",
+    "id": "qu-09-145794",
+    "coordinates": [
+      -73.82816,
+      40.711072
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2446 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119942",
+    "coordinates": [
+      -73.94055195,
+      40.81991621
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "896 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120533",
+    "coordinates": [
+      -73.9668303,
+      40.79908844
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118-10 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145763",
+    "coordinates": [
+      -73.832341,
+      40.714861
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "845 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133477",
+    "coordinates": [
+      -73.96981621,
+      40.75691135
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "165 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133339",
+    "coordinates": [
+      -73.98617513,
+      40.73447281
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 CLIFFORD PLACE",
+    "type": "LINK1.0",
+    "id": "bx-05-146094",
+    "coordinates": [
+      -73.912958,
+      40.846434
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "489 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121502",
+    "coordinates": [
+      -73.978416,
+      40.745116
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "244 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145876",
+    "coordinates": [
+      -73.99277254,
+      40.68343607
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "461 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-135518",
+    "coordinates": [
+      -73.99011216,
+      40.75152164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110-30 FARMERS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123883",
+    "coordinates": [
+      -73.7663008,
+      40.7023712
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "104 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135039",
+    "coordinates": [
+      -74.001807,
+      40.740531
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "59-40 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-124939",
+    "coordinates": [
+      -73.904656,
+      40.741288
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "202 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-126673",
+    "coordinates": [
+      -73.94338965,
+      40.70892202
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141-40 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-07-137929",
+    "coordinates": [
+      -73.8240179,
+      40.764482
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "143 CENTRAL AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-150244",
+    "coordinates": [
+      -73.9274649,
+      40.6995843
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "112-25 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145889",
+    "coordinates": [
+      -73.83565709,
+      40.69790215
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "877 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121669",
+    "coordinates": [
+      -73.96665144,
+      40.75341389
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "88-22 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-125377",
+    "coordinates": [
+      -73.8780368,
+      40.7503431
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-02 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-143455",
+    "coordinates": [
+      -73.88507204,
+      40.7496063
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "211 BOWERY",
+    "type": "LINK1.0",
+    "id": "mn-03-100726",
+    "coordinates": [
+      -73.993454,
+      40.721425
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "343 EAST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-135072",
+    "coordinates": [
+      -73.95894778,
+      40.76411658
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "136-09 FARMERS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-155281",
+    "coordinates": [
+      -73.763428,
+      40.6746405
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2926 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-145541",
+    "coordinates": [
+      -73.93727923,
+      40.82900248
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1995 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121323",
+    "coordinates": [
+      -73.98236687,
+      40.77544328
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4791 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-134409",
+    "coordinates": [
+      -73.9258056,
+      40.8661515
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3798 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-135063",
+    "coordinates": [
+      -73.944329,
+      40.834513
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98-31 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145882",
+    "coordinates": [
+      -73.84665595,
+      40.69504845
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "63 GUERNSEY STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146011",
+    "coordinates": [
+      -73.95260309,
+      40.72329009
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 EAST 34 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121576",
+    "coordinates": [
+      -73.9810645,
+      40.74688075
+    ]
+  },
+  {
+    "street_address": "798 HUNTS POINT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-118974",
+    "coordinates": [
+      -73.8876715,
+      40.8164562
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82 WEST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-145924",
+    "coordinates": [
+      -73.90070588,
+      40.86810029
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94 BAYARD STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-123448",
+    "coordinates": [
+      -73.9993002,
+      40.7160332
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "34-01 38 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-136769",
+    "coordinates": [
+      -73.92905463,
+      40.75227852
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30 EAST 76 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121036",
+    "coordinates": [
+      -73.96346015,
+      40.77428147
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "150 EAST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-120249",
+    "coordinates": [
+      -73.941542,
+      40.798488
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3457 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-141129",
+    "coordinates": [
+      -73.95258142,
+      40.82382134
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "927 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-04-156543",
+    "coordinates": [
+      -73.9358249,
+      40.6975166
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2239 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-137051",
+    "coordinates": [
+      -73.9797962,
+      40.78442303
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 EAST 64 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-135119",
+    "coordinates": [
+      -73.95945972744822,
+      40.76258315803982
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "275 LIVINGSTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126838",
+    "coordinates": [
+      -73.98247226,
+      40.68844943
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "74-18 37 AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-03-132974",
+    "coordinates": [
+      -73.8910703,
+      40.7489749
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "544 BUSHWICK AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-150039",
+    "coordinates": [
+      -73.9358433,
+      40.6994752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "197 LINCOLN AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145916",
+    "coordinates": [
+      -73.92788597,
+      40.81015856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "856 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-126619",
+    "coordinates": [
+      -73.958717,
+      40.6688
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-56 WOODHAVEN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-09-145989",
+    "coordinates": [
+      -73.85255707,
+      40.69373978
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "661 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-135057",
+    "coordinates": [
+      -73.96915525,
+      40.79044448
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "549 CLASSON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145748",
+    "coordinates": [
+      -73.958535,
+      40.681853
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "803 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-145833",
+    "coordinates": [
+      -73.9505023,
+      40.66916742
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "981 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120640",
+    "coordinates": [
+      -73.9617454,
+      40.80059158
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "27 EAST 32 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121641",
+    "coordinates": [
+      -73.98371405,
+      40.74646478
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "511 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-108952",
+    "coordinates": [
+      -73.94996349,
+      40.70537096
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "27-20 43 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-139595",
+    "coordinates": [
+      -73.94141973,
+      40.74766699
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "712 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134657",
+    "coordinates": [
+      -73.97382819,
+      40.74739525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "134 EAST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-138326",
+    "coordinates": [
+      -73.97170313,
+      40.75779319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2299 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121304",
+    "coordinates": [
+      -73.9783,
+      40.786403
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1052 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145789",
+    "coordinates": [
+      -73.95814408,
+      40.6452617
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "35 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138537",
+    "coordinates": [
+      -73.98926217,
+      40.73023165
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-18 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-145953",
+    "coordinates": [
+      -73.9143831,
+      40.75672431
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "680 MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146074",
+    "coordinates": [
+      -73.91616313,
+      40.81939415
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "207 WEST 34 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121998",
+    "coordinates": [
+      -73.99106942,
+      40.75127386
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "307 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-126502",
+    "coordinates": [
+      -73.97325278,
+      40.67845279
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "122-01 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-152551",
+    "coordinates": [
+      -73.7690859,
+      40.6835572
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23 WALKER STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-108445",
+    "coordinates": [
+      -74.004974,
+      40.719679
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "256 ST. ANN'S AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-117230",
+    "coordinates": [
+      -73.91700042,
+      40.80737752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "565 WEST 174 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120755",
+    "coordinates": [
+      -73.93684737,
+      40.84475573
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "775 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136609",
+    "coordinates": [
+      -73.99147237,
+      40.74493317
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "263 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-123117",
+    "coordinates": [
+      -74.00238535,
+      40.7295577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2288 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119996",
+    "coordinates": [
+      -73.95209309,
+      40.80873329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "159 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-108537",
+    "coordinates": [
+      -74.00094,
+      40.742297
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "740 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-107819",
+    "coordinates": [
+      -73.98778563,
+      40.75966968
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "590 WEST 187 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-131063",
+    "coordinates": [
+      -73.93082739,
+      40.85291726
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50-15 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "QU-02-157852",
+    "coordinates": [
+      -73.9140299,
+      40.7443305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "675 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133439",
+    "coordinates": [
+      -73.97414806,
+      40.75096552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "514 RICHMOND TERRACE",
+    "type": "LINK1.0",
+    "id": "si-01-158932",
+    "coordinates": [
+      -74.0895158,
+      40.6462984
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "49 WEST 72 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-119836",
+    "coordinates": [
+      -73.97844368,
+      40.77737709
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2061 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133652",
+    "coordinates": [
+      -73.98225464,
+      40.77814804
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "871 BROOK AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-03-146043",
+    "coordinates": [
+      -73.91069013,
+      40.82251879
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121831",
+    "coordinates": [
+      -73.9701433,
+      40.75632633
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120262",
+    "coordinates": [
+      -73.96421034,
+      40.80804124
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87 BARROW STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123612",
+    "coordinates": [
+      -74.00640751,
+      40.73159252
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "205 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133890",
+    "coordinates": [
+      -73.985171,
+      40.735839
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "230 WEST 97 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120513",
+    "coordinates": [
+      -73.971048,
+      40.795171
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "557 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122565",
+    "coordinates": [
+      -73.99181602,
+      40.75466587
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1456 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-119814",
+    "coordinates": [
+      -73.93292644,
+      40.8502485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "291 NEW DORP LANE",
+    "type": "LINK1.0",
+    "id": "si-02-145729",
+    "coordinates": [
+      -74.11267359,
+      40.57210026
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1800 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-135244",
+    "coordinates": [
+      -73.94577543,
+      40.82792507
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "260 EAST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121791",
+    "coordinates": [
+      -73.96964871,
+      40.7536606
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "77-14 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136653",
+    "coordinates": [
+      -73.88792592,
+      40.74715289
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2018 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-108233",
+    "coordinates": [
+      -73.98196294,
+      40.77600984
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1945 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120222",
+    "coordinates": [
+      -73.94398813,
+      40.7922967
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-145538",
+    "coordinates": [
+      -74.00797977,
+      40.72287042
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "660 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121362",
+    "coordinates": [
+      -73.97446736,
+      40.75095973
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "841 WEST END AVENUE",
+    "type": "Public Payphones",
+    "id": "mn-07-120509",
+    "coordinates": [
+      -73.97091731,
+      40.7985831
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "678 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121354",
+    "coordinates": [
+      -73.989252,
+      40.757753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "330 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121662",
+    "coordinates": [
+      -73.97924601,
+      40.75300305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "418 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-122032",
+    "coordinates": [
+      -73.98165945,
+      40.73087757
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "187-2 HILLSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-118471",
+    "coordinates": [
+      -73.7751334,
+      40.7145203
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "589 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122078",
+    "coordinates": [
+      -73.99137086,
+      40.75528084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "769 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134867",
+    "coordinates": [
+      -73.99105738,
+      40.7658753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "341 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-133657",
+    "coordinates": [
+      -73.98538547,
+      40.74132322
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-17 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125077",
+    "coordinates": [
+      -73.919926,
+      40.75949
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10 WEST 15 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-137100",
+    "coordinates": [
+      -73.993513,
+      40.736806
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "636 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134626",
+    "coordinates": [
+      -73.99439314,
+      40.74051298
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2430 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133632",
+    "coordinates": [
+      -73.974462,
+      40.79069
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-20 55 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-145775",
+    "coordinates": [
+      -73.87625423,
+      40.7353874
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3301 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-126297",
+    "coordinates": [
+      -73.94651287,
+      40.65102676
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "801 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-138188",
+    "coordinates": [
+      -73.97189334,
+      40.75045756
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1238 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111621",
+    "coordinates": [
+      -73.93780684,
+      40.84356713
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1605 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-145838",
+    "coordinates": [
+      -73.91292955,
+      40.84388121
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "197-48 JAMAICA AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123702",
+    "coordinates": [
+      -73.7613347,
+      40.7133328
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "748 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121429",
+    "coordinates": [
+      -73.97296141,
+      40.74857853
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "907 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-139460",
+    "coordinates": [
+      -73.98447,
+      40.764744
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-07 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-100721",
+    "coordinates": [
+      -73.92421781,
+      40.76150726
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3599 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134795",
+    "coordinates": [
+      -73.94929876,
+      40.82831959
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2060 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121346",
+    "coordinates": [
+      -73.981853,
+      40.777921
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "124 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-128751",
+    "coordinates": [
+      -73.98781752,
+      40.72823169
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "35-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-142852",
+    "coordinates": [
+      -73.92201908,
+      40.76047267
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "15 FEATHERBED LANE",
+    "type": "LINK1.0",
+    "id": "bx-05-119131",
+    "coordinates": [
+      -73.9144562,
+      40.8457007
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "106 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-122319",
+    "coordinates": [
+      -74.00101556,
+      40.7180331
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "850 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-139576",
+    "coordinates": [
+      -73.97047,
+      40.756577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-01 33 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-133224",
+    "coordinates": [
+      -73.91988166,
+      40.76592997
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2437 GRAND CONCOURSE",
+    "type": "LINK1.0",
+    "id": "bx-05-119575",
+    "coordinates": [
+      -73.898023,
+      40.861349
+    ]
+  },
+  {
+    "street_address": "1340 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120646",
+    "coordinates": [
+      -73.935456,
+      40.846771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1400 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120769",
+    "coordinates": [
+      -73.9340696,
+      40.84867304
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124791",
+    "coordinates": [
+      -73.85118474,
+      40.69396285
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "441 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135591",
+    "coordinates": [
+      -73.97998543,
+      40.73934123
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160-15 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141545",
+    "coordinates": [
+      -73.79869023,
+      40.70402028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "215 WEST 75 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121224",
+    "coordinates": [
+      -73.98096599,
+      40.78094218
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "712 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122269",
+    "coordinates": [
+      -73.9927995,
+      40.74272274
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "162 PARK PLACE",
+    "type": "LINK1.0",
+    "id": "bk-06-145848",
+    "coordinates": [
+      -73.9730618,
+      40.67758878
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3300 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120412",
+    "coordinates": [
+      -73.95579589,
+      40.81881338
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-145997",
+    "coordinates": [
+      -73.95131072,
+      40.71086983
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "31 NASSAU AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145999",
+    "coordinates": [
+      -73.95323355,
+      40.7230135
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2518 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133624",
+    "coordinates": [
+      -73.97264858,
+      40.79318087
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3368 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145942",
+    "coordinates": [
+      -73.87137973,
+      40.68382059
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-04 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125132",
+    "coordinates": [
+      -73.92045929,
+      40.76638612
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "827 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145755",
+    "coordinates": [
+      -73.95911529,
+      40.65245679
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2710 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119897",
+    "coordinates": [
+      -73.94223468,
+      40.82221486
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70-25 YELLOWSTONE BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124234",
+    "coordinates": [
+      -73.85077696,
+      40.72249917
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "219 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146015",
+    "coordinates": [
+      -73.95953976,
+      40.71385109
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "704 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122658",
+    "coordinates": [
+      -73.98463666,
+      40.75937884
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "270 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125931",
+    "coordinates": [
+      -73.98193577,
+      40.67455551
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "120 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-138190",
+    "coordinates": [
+      -73.9982041,
+      40.74077246
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2214 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-145818",
+    "coordinates": [
+      -73.90761958,
+      40.67803579
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "91 HOYT STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126016",
+    "coordinates": [
+      -73.98698898,
+      40.68760943
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "161-21 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141537",
+    "coordinates": [
+      -73.79786531,
+      40.7043551
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2373 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134318",
+    "coordinates": [
+      -73.97641054,
+      40.7887051
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2293 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142814",
+    "coordinates": [
+      -73.95214914,
+      40.80899649
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "210 CANAL STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-108162",
+    "coordinates": [
+      -73.99907941,
+      40.71716821
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "220 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145905",
+    "coordinates": [
+      -73.9921845,
+      40.68430374
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "595 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123136",
+    "coordinates": [
+      -73.99547509,
+      40.73943218
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4802 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-126271",
+    "coordinates": [
+      -73.932187,
+      40.65159
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "182 BEDFORD AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-140988",
+    "coordinates": [
+      -73.95786908,
+      40.71777024
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1876 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119631",
+    "coordinates": [
+      -73.910931,
+      40.849486
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1271 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120991",
+    "coordinates": [
+      -73.959928,
+      40.770456
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "241 CRESCENT STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145943",
+    "coordinates": [
+      -73.872079,
+      40.683506
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1915 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-132876",
+    "coordinates": [
+      -73.94478351,
+      40.79120304
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1041 WEST FARMS ROAD",
+    "type": "LINK1.0",
+    "id": "bx-02-123197",
+    "coordinates": [
+      -73.8916355,
+      40.8249375
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "886 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136065",
+    "coordinates": [
+      -73.98809867,
+      40.76956734
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "357 GRAND STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-123344",
+    "coordinates": [
+      -73.9891563,
+      40.7164842
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "224 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-121470",
+    "coordinates": [
+      -73.98482253,
+      40.732206
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "243 WEST 99 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107801",
+    "coordinates": [
+      -73.97065155,
+      40.79676125
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1216 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122180",
+    "coordinates": [
+      -73.988399,
+      40.746624
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "399 WEST BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-02-133259",
+    "coordinates": [
+      -74.00202234,
+      40.72433792
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "750 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134490",
+    "coordinates": [
+      -73.99188287,
+      40.7439707
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "245 EAST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121457",
+    "coordinates": [
+      -73.98105517,
+      40.73805173
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "337 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145894",
+    "coordinates": [
+      -73.98362685,
+      40.67224181
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2116 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145785",
+    "coordinates": [
+      -73.94766296,
+      40.74492115
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "67 FEATHERBED LANE",
+    "type": "LINK1.0",
+    "id": "bx-05-116200",
+    "coordinates": [
+      -73.9172755,
+      40.8464399
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1000 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121683",
+    "coordinates": [
+      -73.96381797,
+      40.75687875
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "568 WEST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-123504",
+    "coordinates": [
+      -74.00690371,
+      40.74875784
+    ]
+  },
+  {
+    "street_address": "601 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125916",
+    "coordinates": [
+      -73.990353,
+      40.664176
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "75-10 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-145915",
+    "coordinates": [
+      -73.89012129,
+      40.74604558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "105 EAST 165 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119048",
+    "coordinates": [
+      -73.921747,
+      40.831467
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "104-20 DUNKIRK STREET",
+    "type": "LINK1.0",
+    "id": "qu-12-154633",
+    "coordinates": [
+      -73.7752581,
+      40.7052036
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "735 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136045",
+    "coordinates": [
+      -73.99196653,
+      40.76462448
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-02 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-125322",
+    "coordinates": [
+      -73.87652268,
+      40.74834975
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "256 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145857",
+    "coordinates": [
+      -73.94373207,
+      40.7110789
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1966 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120221",
+    "coordinates": [
+      -73.94378353,
+      40.7930088
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "39-27 31 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-145980",
+    "coordinates": [
+      -73.93337963,
+      40.75195044
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "164 EAST 84 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121020",
+    "coordinates": [
+      -73.955153,
+      40.777528
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "126 NORTH 8 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146014",
+    "coordinates": [
+      -73.95861248,
+      40.71924622
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "908 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122615",
+    "coordinates": [
+      -73.98422945,
+      40.76464619
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "685 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-137452",
+    "coordinates": [
+      -73.97452006,
+      40.74686754
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1745 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-118228",
+    "coordinates": [
+      -73.98212946,
+      40.76534122
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2105 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120229",
+    "coordinates": [
+      -73.940337,
+      40.797303
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1642 PITKIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-155175",
+    "coordinates": [
+      -73.9124331,
+      40.6693682
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "21-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125170",
+    "coordinates": [
+      -73.93142777,
+      40.76516019
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1430 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111720",
+    "coordinates": [
+      -73.93332247,
+      40.84969774
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101-20 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-128370",
+    "coordinates": [
+      -73.852197,
+      40.726082
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "116-52 FARMERS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-128104",
+    "coordinates": [
+      -73.7625217,
+      40.6920908
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1505 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121019",
+    "coordinates": [
+      -73.954428,
+      40.778003
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "455 WEST 53 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-137195",
+    "coordinates": [
+      -73.9902101,
+      40.76668319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1123 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-123647",
+    "coordinates": [
+      -73.98920582,
+      40.74320284
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "552 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122272",
+    "coordinates": [
+      -73.99615313,
+      40.73810851
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "113 BOWERY",
+    "type": "LINK1.0",
+    "id": "mn-03-108422",
+    "coordinates": [
+      -73.99494009,
+      40.71791958
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "139 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134551",
+    "coordinates": [
+      -74.00132086,
+      40.74162142
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-108516",
+    "coordinates": [
+      -73.98532503,
+      40.72779351
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "78 ROCKAWAY AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-158252",
+    "coordinates": [
+      -73.9114697,
+      40.6811003
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1467 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-146114",
+    "coordinates": [
+      -73.95336989,
+      40.81715705
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121377",
+    "coordinates": [
+      -73.9767944,
+      40.75013253
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "24 EAST 70 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121140",
+    "coordinates": [
+      -73.96660446,
+      40.77051657
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36 NEVINS STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-108350",
+    "coordinates": [
+      -73.98192018,
+      40.68745727
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "517 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145830",
+    "coordinates": [
+      -73.9495225,
+      40.67948543
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25-35 ASTORIA BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-146088",
+    "coordinates": [
+      -73.92149601,
+      40.7710546
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4100 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120796",
+    "coordinates": [
+      -73.93878768,
+      40.84449293
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-10 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-126733",
+    "coordinates": [
+      -73.86199361,
+      40.69210611
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3153 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-136680",
+    "coordinates": [
+      -73.95937,
+      40.81450454
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "190 EAST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-137315",
+    "coordinates": [
+      -73.97008839,
+      40.75711322
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2122 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-145962",
+    "coordinates": [
+      -73.91218476,
+      40.67828559
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "529 EASTERN PARKWAY",
+    "type": "LINK1.0",
+    "id": "bk-08-126469",
+    "coordinates": [
+      -73.950627,
+      40.670115
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "481 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-133371",
+    "coordinates": [
+      -73.97340729,
+      40.78461205
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "215 WEST 88 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121243",
+    "coordinates": [
+      -73.97504101,
+      40.78945727
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123539",
+    "coordinates": [
+      -73.99993241,
+      40.73857046
+    ]
+  },
+  {
+    "street_address": "576 WEST 150 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120442",
+    "coordinates": [
+      -73.94764707,
+      40.82934138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1626 CORTELYOU ROAD",
+    "type": "LINK1.0",
+    "id": "bk-14-126362",
+    "coordinates": [
+      -73.96283585,
+      40.64185835
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1133 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145864",
+    "coordinates": [
+      -73.95545319,
+      40.73691349
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "84 EAST 167 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-145851",
+    "coordinates": [
+      -73.91979703,
+      40.83513298
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-139058",
+    "coordinates": [
+      -73.98822418,
+      40.72380705
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1223 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135066",
+    "coordinates": [
+      -73.96208669,
+      40.76389092
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "691 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126628",
+    "coordinates": [
+      -73.97820169,
+      40.68788961
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1251 EAST BAY AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-156328",
+    "coordinates": [
+      -73.8869266,
+      40.8086054
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "954 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-138438",
+    "coordinates": [
+      -73.9675385,
+      40.76045676
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2853 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134414",
+    "coordinates": [
+      -73.96657376,
+      40.80464541
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-126669",
+    "coordinates": [
+      -73.942563,
+      40.702936
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-50 50 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-146035",
+    "coordinates": [
+      -73.9116866,
+      40.75448755
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "581 WEST 161 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120445",
+    "coordinates": [
+      -73.942787,
+      40.836501
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2505 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119634",
+    "coordinates": [
+      -73.8919913,
+      40.8612722
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "290 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-138267",
+    "coordinates": [
+      -73.99428583,
+      40.74615485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "890 HUNTS POINT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-145646",
+    "coordinates": [
+      -73.8894699,
+      40.8193276
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "458 UNION AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-146081",
+    "coordinates": [
+      -73.95155241,
+      40.71419088
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "208 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-107898",
+    "coordinates": [
+      -73.98319263,
+      40.73030035
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "162-02 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141538",
+    "coordinates": [
+      -73.79774312,
+      40.70421585
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "11 NAGLE AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120808",
+    "coordinates": [
+      -73.9308578,
+      40.8592443
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2914 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-118944",
+    "coordinates": [
+      -73.91582926,
+      40.817235
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2659 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133620",
+    "coordinates": [
+      -73.969557,
+      40.798018
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1172 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120986",
+    "coordinates": [
+      -73.96252262,
+      40.76733135
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "574 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134640",
+    "coordinates": [
+      -73.97141311,
+      40.78769783
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "344 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123800",
+    "coordinates": [
+      -73.98324565,
+      40.73153857
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121631",
+    "coordinates": [
+      -73.98664796,
+      40.74257286
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3480 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145938",
+    "coordinates": [
+      -73.86677733,
+      40.68513094
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "170 WEST 25 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-134558",
+    "coordinates": [
+      -73.99456317,
+      40.74526758
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "88-03 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136452",
+    "coordinates": [
+      -73.87816548,
+      40.74831104
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2338 LORING PLACE NORTH",
+    "type": "LINK1.0",
+    "id": "bx-07-144372",
+    "coordinates": [
+      -73.907548,
+      40.862685
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1950 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-143074",
+    "coordinates": [
+      -73.94423011,
+      40.79239362
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38-04 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125081",
+    "coordinates": [
+      -73.919649,
+      40.759199
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "845 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133472",
+    "coordinates": [
+      -73.97011147,
+      40.75650489
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "900 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135879",
+    "coordinates": [
+      -73.96895056,
+      40.7585484
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2255 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121300",
+    "coordinates": [
+      -73.97924562,
+      40.78513453
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "109-14 MERRICK BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-118473",
+    "coordinates": [
+      -73.7842625,
+      40.6968902
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "921 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-136701",
+    "coordinates": [
+      -73.96311539,
+      40.79871675
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 DEVOE STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146022",
+    "coordinates": [
+      -73.95128474,
+      40.71307988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1948 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-119388",
+    "coordinates": [
+      -73.90003051,
+      40.84909302
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "116-02 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-156309",
+    "coordinates": [
+      -73.7766491,
+      40.6882211
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "540 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134834",
+    "coordinates": [
+      -73.97769449,
+      40.74206862
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "518 GERARD AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145688",
+    "coordinates": [
+      -73.92921294,
+      40.81888599
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-142873",
+    "coordinates": [
+      -73.91730276,
+      40.76490229
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "444 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134831",
+    "coordinates": [
+      -73.97946572,
+      40.73964666
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "837 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-126617",
+    "coordinates": [
+      -73.95826142,
+      40.66965209
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-26 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136657",
+    "coordinates": [
+      -73.87146338,
+      40.74887831
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "108 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136386",
+    "coordinates": [
+      -73.99282602,
+      40.73727988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "535 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121993",
+    "coordinates": [
+      -73.98832163,
+      40.75397801
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "333 BALTIC STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145906",
+    "coordinates": [
+      -73.99158104,
+      40.68479895
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2245 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133393",
+    "coordinates": [
+      -73.979564,
+      40.784712
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "225 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123657",
+    "coordinates": [
+      -74.00417706,
+      40.74788855
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "501 WEST 140 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-118226",
+    "coordinates": [
+      -73.950118,
+      40.822212
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "949 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-107988",
+    "coordinates": [
+      -73.968444,
+      40.755193
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "192 EAST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-144673",
+    "coordinates": [
+      -73.936139,
+      40.803731
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2275 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121238",
+    "coordinates": [
+      -73.97878535,
+      40.78575329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1622 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119833",
+    "coordinates": [
+      -73.951699,
+      40.782159
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "289 MORRIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146049",
+    "coordinates": [
+      -73.92658962,
+      40.81207894
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "470 WEST 157 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120461",
+    "coordinates": [
+      -73.94188652,
+      40.83274898
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "799 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-02-123086",
+    "coordinates": [
+      -73.99138693,
+      40.73239147
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "403 MYRTLE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-02-143595",
+    "coordinates": [
+      -73.9697882,
+      40.6933089
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "63 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125928",
+    "coordinates": [
+      -73.97744609,
+      40.6807318
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "849 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122482",
+    "coordinates": [
+      -73.98921452,
+      40.76840586
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "670 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-107818",
+    "coordinates": [
+      -73.989409,
+      40.757544
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "154 EAST 29 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121495",
+    "coordinates": [
+      -73.980628,
+      40.742625
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "191 AVENUE A",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-123419",
+    "coordinates": [
+      -73.9814896,
+      40.7290116
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "856 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120535",
+    "coordinates": [
+      -73.96774773,
+      40.79782619
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2212 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-125465",
+    "coordinates": [
+      -74.103479,
+      40.576541
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4201 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125840",
+    "coordinates": [
+      -74.00828534,
+      40.65039017
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82 WEST 91 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121120",
+    "coordinates": [
+      -73.96964431,
+      40.7895412
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 EAST 56 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-134222",
+    "coordinates": [
+      -73.97274462,
+      40.76151071
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1211 GRANDVIEW PLACE",
+    "type": "LINK1.0",
+    "id": "bx-04-119152",
+    "coordinates": [
+      -73.9182259,
+      40.83490416
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "280 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145875",
+    "coordinates": [
+      -73.99346713,
+      40.68240987
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "430 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122446",
+    "coordinates": [
+      -73.99113025,
+      40.75048843
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "540 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145796",
+    "coordinates": [
+      -73.95570356,
+      40.68095126
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "308 WEST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-122605",
+    "coordinates": [
+      -73.98583017,
+      40.76305136
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "85-10 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-03-125399",
+    "coordinates": [
+      -73.881778,
+      40.755835
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "991 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121734",
+    "coordinates": [
+      -73.9663883,
+      40.76160412
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2565 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133636",
+    "coordinates": [
+      -73.97185626,
+      40.79489566
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "550 VANDERBILT AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145903",
+    "coordinates": [
+      -73.96799938,
+      40.68042562
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1351 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-125479",
+    "coordinates": [
+      -74.08620985,
+      40.59545604
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "584 ROCKAWAY AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-113558",
+    "coordinates": [
+      -73.9098878,
+      40.6656616
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-02 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136456",
+    "coordinates": [
+      -73.8846895,
+      40.74748994
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 EAST 31 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121624",
+    "coordinates": [
+      -73.98581619,
+      40.74642561
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "828 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136682",
+    "coordinates": [
+      -73.97106076,
+      40.75118754
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "320 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-10-120621",
+    "coordinates": [
+      -73.952053,
+      40.811325
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46-02 GREENPOINT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-124996",
+    "coordinates": [
+      -73.91873252,
+      40.74218025
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1021 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121694",
+    "coordinates": [
+      -73.96359345,
+      40.75760431
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "305 EAST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-111503",
+    "coordinates": [
+      -73.90095411,
+      40.85054841
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "143 WAVERLY AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-02-127466",
+    "coordinates": [
+      -73.9676714,
+      40.693311
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1417 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-140440",
+    "coordinates": [
+      -73.95450726,
+      40.81559377
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "243 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-123822",
+    "coordinates": [
+      -73.984486,
+      40.736789
+    ]
+  },
+  {
+    "street_address": "734 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136381",
+    "coordinates": [
+      -73.99158984,
+      40.76478628
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "181 EAST 90 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-119821",
+    "coordinates": [
+      -73.952279,
+      40.781503
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2361 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145737",
+    "coordinates": [
+      -74.10691685,
+      40.57346599
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "402 HUNTS POINT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-145542",
+    "coordinates": [
+      -73.8807035,
+      40.8097136
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2197 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142513",
+    "coordinates": [
+      -73.94591692,
+      40.81197343
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "596 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121519",
+    "coordinates": [
+      -73.97602629,
+      40.7488188
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "685 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121535",
+    "coordinates": [
+      -73.973765,
+      40.751497
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98-108 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145764",
+    "coordinates": [
+      -73.854789,
+      40.727095
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1403 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120554",
+    "coordinates": [
+      -73.954837,
+      40.81515
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2172 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-106683",
+    "coordinates": [
+      -73.9389231,
+      40.79965855
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "720 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-146084",
+    "coordinates": [
+      -73.95682638,
+      40.67403887
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2504 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119882",
+    "coordinates": [
+      -73.94700174,
+      40.81569589
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "296 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146083",
+    "coordinates": [
+      -73.92192323,
+      40.8102552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1780 UNIVERSITY AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-05-119738",
+    "coordinates": [
+      -73.915169,
+      40.850245
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141 LIVINGSTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-126847",
+    "coordinates": [
+      -73.9879984,
+      40.69059444
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "325 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-135935",
+    "coordinates": [
+      -74.007487,
+      40.726889
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "183 CALYER STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-125268",
+    "coordinates": [
+      -73.953439,
+      40.728133
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "130 DYCKMAN STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-141128",
+    "coordinates": [
+      -73.9253949,
+      40.8623929
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "416 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-138795",
+    "coordinates": [
+      -73.98039603,
+      40.73838376
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "317 LEFFERTS AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-145844",
+    "coordinates": [
+      -73.950605,
+      40.662438
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38-02 31 STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-145923",
+    "coordinates": [
+      -73.93221564,
+      40.75371822
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "142 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136455",
+    "coordinates": [
+      -74.001088,
+      40.74151
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "710 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-119017",
+    "coordinates": [
+      -73.91293263,
+      40.80470552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "249 CHURCH STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-109587",
+    "coordinates": [
+      -74.00560969,
+      40.71772575
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1600 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-133361",
+    "coordinates": [
+      -73.9845408,
+      40.76041294
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "364 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146007",
+    "coordinates": [
+      -73.95561039,
+      40.71226766
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "221 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-107977",
+    "coordinates": [
+      -73.99939787,
+      40.74426003
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-123261",
+    "coordinates": [
+      -73.987384,
+      40.73347
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32-44 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-124952",
+    "coordinates": [
+      -73.93187521,
+      40.74445002
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1966 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119597",
+    "coordinates": [
+      -73.90897566,
+      40.85187831
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "846 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-03-108944",
+    "coordinates": [
+      -73.93893235,
+      40.69895576
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "91 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123816",
+    "coordinates": [
+      -73.987938,
+      40.732039
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3402 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-145928",
+    "coordinates": [
+      -73.94554463,
+      40.65094749
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 42 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-137072",
+    "coordinates": [
+      -73.97408803,
+      40.75071654
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43 SNYDER AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145929",
     "coordinates": [
       -73.95596197,
       40.64868919
@@ -14904,31 +12276,169 @@
     "status": "active"
   },
   {
-    "id": "LINK-022142",
+    "street_address": "522 WEST 168 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120681",
     "coordinates": [
-      -73.95781959,
-      40.64860712
+      -73.9382392,
+      40.8403607
     ],
     "status": "active"
   },
   {
-    "id": "LINK-022296",
+    "street_address": "791 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127030",
     "coordinates": [
-      -73.95968841,
-      40.718187
+      -73.950397,
+      40.670147
     ],
     "status": "active"
   },
   {
-    "id": "LINK-022396",
+    "street_address": "2361 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-120055",
     "coordinates": [
-      -73.95586492,
-      40.81410283
+      -73.942056,
+      40.817264
     ],
-    "status": "installed"
+    "status": "active"
   },
   {
-    "id": "LINK-022685",
+    "street_address": "56 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123295",
+    "coordinates": [
+      -73.98733637,
+      40.724614
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 71 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120995",
+    "coordinates": [
+      -73.96096732,
+      40.76893883
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1091 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-136012",
+    "coordinates": [
+      -73.96404982,
+      40.76483327
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "115-09 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-128721",
+    "coordinates": [
+      -73.83383439,
+      40.69889972
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2017 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134429",
+    "coordinates": [
+      -73.98233804,
+      40.77623753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 WEST 54 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122860",
+    "coordinates": [
+      -73.97568365,
+      40.76111775
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1595 FOREST AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "si-01-125505",
+    "coordinates": [
+      -74.141731,
+      40.6247117
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "251 WEST 105 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120277",
+    "coordinates": [
+      -73.96826,
+      40.800681
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "800 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133688",
+    "coordinates": [
+      -73.99077541,
+      40.74549407
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3 EDWARD MORGAN PLACE",
+    "type": "LINK1.0",
+    "id": "mn-12-120347",
+    "coordinates": [
+      -73.945436,
+      40.834974
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48 WEST FORDHAM ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119564",
+    "coordinates": [
+      -73.90324404,
+      40.86264365
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "724 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122092",
+    "coordinates": [
+      -73.98818717,
+      40.75922149
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1020 KELLY STREET",
+    "type": "LINK1.0",
+    "id": "bx-02-152585",
+    "coordinates": [
+      -73.8956821,
+      40.8239453
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "79-20 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-146071",
     "coordinates": [
       -73.88645545,
       40.74945855
@@ -14936,7 +12446,6320 @@
     "status": "active"
   },
   {
-    "id": "LINK-022686",
+    "street_address": "3659 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120356",
+    "coordinates": [
+      -73.94791148,
+      40.83020903
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "26 WEST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119873",
+    "coordinates": [
+      -73.89873,
+      40.867627
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "148-07 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141534",
+    "coordinates": [
+      -73.806477,
+      40.701853
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "416 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134561",
+    "coordinates": [
+      -73.98024173,
+      40.7430352
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "122B ORCHARD STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-137963",
+    "coordinates": [
+      -73.98947427,
+      40.71950376
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "701 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-142001",
+    "coordinates": [
+      -73.98890049,
+      40.75866608
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "221 WEST 81 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-138882",
+    "coordinates": [
+      -73.97863267,
+      40.78506849
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "374 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146023",
+    "coordinates": [
+      -73.9205525,
+      40.81212659
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "899 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122768",
+    "coordinates": [
+      -73.98867303,
+      40.74877222
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "948 EAST 163 STREET",
+    "type": "LINK1.0",
+    "id": "bx-02-111492",
+    "coordinates": [
+      -73.8960554,
+      40.8209021
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-119952",
+    "coordinates": [
+      -73.94859133,
+      40.80918643
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "180 VARICK STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123589",
+    "coordinates": [
+      -74.00540707,
+      40.72728365
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "375 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-122264",
+    "coordinates": [
+      -74.00023841,
+      40.73288433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1431 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122169",
+    "coordinates": [
+      -73.98693515,
+      40.75449299
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1986 FULTON STREET",
+    "type": "LINK5G_Ad",
+    "id": "bk-03-144136",
+    "coordinates": [
+      -73.9189999,
+      40.6785723
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "134 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123794",
+    "coordinates": [
+      -73.98511899,
+      40.72764987
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "285 MILL ROAD",
+    "type": "LINK1.0",
+    "id": "si-03-125464",
+    "coordinates": [
+      -74.11216061,
+      40.56175506
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2976A 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123212",
+    "coordinates": [
+      -73.91430035,
+      40.81855965
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2256 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120314",
+    "coordinates": [
+      -73.93776628,
+      40.79682481
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "139-04 HILLSIDE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-108654",
+    "coordinates": [
+      -73.8142522,
+      40.7042216
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70-50 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145740",
+    "coordinates": [
+      -73.892498,
+      40.739393
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48-12 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125071",
+    "coordinates": [
+      -73.912336,
+      40.755764
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "190 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123270",
+    "coordinates": [
+      -73.985882,
+      40.730881
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2631 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145931",
+    "coordinates": [
+      -73.89746353,
+      40.67722165
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51 EAST 55 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121964",
+    "coordinates": [
+      -73.97310142,
+      40.76096333
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-20 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145788",
+    "coordinates": [
+      -73.87083775,
+      40.7333421
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "632 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127047",
+    "coordinates": [
+      -73.949935,
+      40.676752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2227 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-107927",
+    "coordinates": [
+      -73.979996,
+      40.784128
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "129 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135516",
+    "coordinates": [
+      -74.00358788,
+      40.74359974
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-133442",
+    "coordinates": [
+      -73.98977798,
+      40.73412708
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "79 HENRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145810",
+    "coordinates": [
+      -73.9925546,
+      40.69828038
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-13 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136305",
+    "coordinates": [
+      -73.87577475,
+      40.74855095
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "378 BEDFORD PARK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-07-119719",
+    "coordinates": [
+      -73.8842536,
+      40.8678557
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1401 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122629",
+    "coordinates": [
+      -73.97719468,
+      40.76451317
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "61 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123537",
+    "coordinates": [
+      -73.99947574,
+      40.73866726
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 VARICK STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-133384",
+    "coordinates": [
+      -74.00648828,
+      40.72098349
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "280 CADMAN PLAZA WEST",
+    "type": "LINK1.0",
+    "id": "bk-02-126247",
+    "coordinates": [
+      -73.99126379,
+      40.69607044
+    ]
+  },
+  {
+    "street_address": "1208 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-127022",
+    "coordinates": [
+      -73.95040697,
+      40.65773965
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "506 UTICA AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-153835",
+    "coordinates": [
+      -73.9314656,
+      40.660758
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "69-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145849",
+    "coordinates": [
+      -73.895296,
+      40.739922
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2114 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-136130",
+    "coordinates": [
+      -73.98139599,
+      40.78001947
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "944 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121795",
+    "coordinates": [
+      -73.96827641,
+      40.75501502
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "488 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134122",
+    "coordinates": [
+      -73.97514297,
+      40.75864931
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "214 WEST 96 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-100260",
+    "coordinates": [
+      -73.97157309,
+      40.79446154
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "728 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121427",
+    "coordinates": [
+      -73.9734053,
+      40.74796623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "344 EAST 11 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-136971",
+    "coordinates": [
+      -73.98430909,
+      40.72944908
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "455 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-135659",
+    "coordinates": [
+      -73.98272283,
+      40.74498361
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1220 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-107873",
+    "coordinates": [
+      -73.95875952,
+      40.7638554
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-119951",
+    "coordinates": [
+      -73.9486889,
+      40.80902187
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "550 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-108433",
+    "coordinates": [
+      -73.991871,
+      40.754171
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3514 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111954",
+    "coordinates": [
+      -73.950907,
+      40.825508
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "248 WEST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-142002",
+    "coordinates": [
+      -73.986836,
+      40.760895
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "962 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121785",
+    "coordinates": [
+      -73.968041,
+      40.755335
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2756 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134073",
+    "coordinates": [
+      -73.967707,
+      40.801084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "653 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122456",
+    "coordinates": [
+      -73.99364234,
+      40.76232841
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "462 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125910",
+    "coordinates": [
+      -73.98695629,
+      40.66853323
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "691 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145867",
+    "coordinates": [
+      -73.996017,
+      40.662189
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2740 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-120391",
+    "coordinates": [
+      -73.967782,
+      40.800581
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 74 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121002",
+    "coordinates": [
+      -73.959496,
+      40.770946
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1407 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145756",
+    "coordinates": [
+      -73.94490293,
+      40.68019738
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "426 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-138788",
+    "coordinates": [
+      -73.91962478,
+      40.813367
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1917 SOUTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-06-101312",
+    "coordinates": [
+      -73.88597436,
+      40.84183354
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "346 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-137326",
+    "coordinates": [
+      -73.996434,
+      40.747905
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "969 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133481",
+    "coordinates": [
+      -73.96710117,
+      40.76064429
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "78-14 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-114647",
+    "coordinates": [
+      -73.86326155,
+      40.69190229
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-01 35 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-143797",
+    "coordinates": [
+      -73.929829,
+      40.744151
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1001 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136356",
+    "coordinates": [
+      -73.96407038,
+      40.75694399
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1520 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120666",
+    "coordinates": [
+      -73.93133833,
+      40.85241173
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "439 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-135635",
+    "coordinates": [
+      -73.98313231,
+      40.74440678
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "947 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122623",
+    "coordinates": [
+      -73.98354761,
+      40.76601142
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "95 WALL STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-135575",
+    "coordinates": [
+      -74.00732188,
+      40.70504418
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2781 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-120266",
+    "coordinates": [
+      -73.968149,
+      40.802455
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "336 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121501",
+    "coordinates": [
+      -73.98242356,
+      40.74004081
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1465 FOREST AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "si-01-155189",
+    "coordinates": [
+      -74.1373888,
+      40.624318
+    ]
+  },
+  {
+    "street_address": "730 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120603",
+    "coordinates": [
+      -73.96770405,
+      40.79280441
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "194 HARMAN STREET",
+    "type": "LINK1.0",
+    "id": "bk-04-152625",
+    "coordinates": [
+      -73.9201937,
+      40.6984819
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-59 46 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-145985",
+    "coordinates": [
+      -73.9190056,
+      40.74130348
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40 EAST 80 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121042",
+    "coordinates": [
+      -73.96153957,
+      40.77691823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "106-20 71 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-06-124230",
+    "coordinates": [
+      -73.844787,
+      40.720017
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "574 EAST 163 STREET",
+    "type": "LINK1.0",
+    "id": "bx-03-146064",
+    "coordinates": [
+      -73.90854944,
+      40.82392555
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3539 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120363",
+    "coordinates": [
+      -73.95071631,
+      40.82637629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2306 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142813",
+    "coordinates": [
+      -73.95170768,
+      40.8092681
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1359 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120772",
+    "coordinates": [
+      -73.93536211,
+      40.84727016
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "857 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121413",
+    "coordinates": [
+      -73.97052358,
+      40.75234297
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "174 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121193",
+    "coordinates": [
+      -73.98363296,
+      40.77606852
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "131 EAST 27 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-108040",
+    "coordinates": [
+      -73.983048,
+      40.742139
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122305",
+    "coordinates": [
+      -73.992762,
+      40.752949
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "118-37 GUY R BREWER BLVD",
+    "type": "LINK1.0",
+    "id": "qu-12-155138",
+    "coordinates": [
+      -73.7818522,
+      40.6826763
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138878",
+    "coordinates": [
+      -73.98684237,
+      40.72529099
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "353 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-123285",
+    "coordinates": [
+      -73.9827647,
+      40.73152105
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "197 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123508",
+    "coordinates": [
+      -73.99989422,
+      40.7435787
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2135 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121315",
+    "coordinates": [
+      -73.98152267,
+      40.78099279
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "99 EAST 34 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-133555",
+    "coordinates": [
+      -73.98106107,
+      40.74705459
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2069 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-145761",
+    "coordinates": [
+      -73.91025266,
+      40.67831185
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1165 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-137966",
+    "coordinates": [
+      -73.96335362,
+      40.76214654
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1253 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-142953",
+    "coordinates": [
+      -73.958321,
+      40.810378
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 EAST 22 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-123077",
+    "coordinates": [
+      -73.986712,
+      40.739409
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2710 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145544",
+    "coordinates": [
+      -74.11422426,
+      40.56585176
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 EAST 32 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121579",
+    "coordinates": [
+      -73.98198711,
+      40.74573985
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "565 WEST 162 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-100190",
+    "coordinates": [
+      -73.942288,
+      40.837104
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "69 EAST 176 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-145839",
+    "coordinates": [
+      -73.9099,
+      40.84833
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "208 WEST 49 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-133511",
+    "coordinates": [
+      -73.98428289,
+      40.76063217
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "132-05 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-159527",
+    "coordinates": [
+      -73.7596774,
+      40.6790585
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "988 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121746",
+    "coordinates": [
+      -73.96677926,
+      40.76148352
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2617 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-120285",
+    "coordinates": [
+      -73.970619,
+      40.796566
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 UNDERHILL AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145935",
+    "coordinates": [
+      -73.96466835,
+      40.68088788
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "162 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123792",
+    "coordinates": [
+      -73.98441867,
+      40.72862184
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1390 RANDALL AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-157804",
+    "coordinates": [
+      -73.8814691,
+      40.8127792
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 30 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121506",
+    "coordinates": [
+      -73.979813,
+      40.743093
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "417 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-102011",
+    "coordinates": [
+      -73.92220947,
+      40.80890966
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "251 CENTRAL AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-157813",
+    "coordinates": [
+      -73.922861,
+      40.6968416
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "130 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136486",
+    "coordinates": [
+      -73.98704351,
+      40.73369379
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "431 CANAL STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-133383",
+    "coordinates": [
+      -74.00677065,
+      40.72301338
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "44-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145948",
+    "coordinates": [
+      -73.91171708,
+      40.76227762
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "866 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121540",
+    "coordinates": [
+      -73.970116,
+      40.752476
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1208 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135869",
+    "coordinates": [
+      -73.95903881,
+      40.76343296
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160-05 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-138097",
+    "coordinates": [
+      -73.79901751,
+      40.70389528
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1339 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-126527",
+    "coordinates": [
+      -73.95360324,
+      40.63855961
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 140 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120371",
+    "coordinates": [
+      -73.953041,
+      40.823326
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2455 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145822",
+    "coordinates": [
+      -74.10895942,
+      40.57143702
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "685 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145992",
+    "coordinates": [
+      -73.956281,
+      40.675141
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "24 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-109091",
+    "coordinates": [
+      -73.94216928,
+      40.70154219
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "408 WEST 207 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-157170",
+    "coordinates": [
+      -73.9173083,
+      40.863688
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "363 EAST 69 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120963",
+    "coordinates": [
+      -73.95757799,
+      40.76599549
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1980 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121339",
+    "coordinates": [
+      -73.98200508,
+      40.77472311
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1661 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120570",
+    "coordinates": [
+      -73.948844,
+      40.823361
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "895 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145813",
+    "coordinates": [
+      -73.95850153,
+      40.65002892
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "879 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122647",
+    "coordinates": [
+      -73.98047755,
+      40.7647181
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "146 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135588",
+    "coordinates": [
+      -73.98665825,
+      40.73422211
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2861 WEBSTER AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-07-153911",
+    "coordinates": [
+      -73.8843348,
+      40.8669715
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48 EAST 183 STREET",
+    "type": "LINK5G_Ad",
+    "id": "bx-05-119607",
+    "coordinates": [
+      -73.9028148,
+      40.8582102
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "150 EAST 188 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-119587",
+    "coordinates": [
+      -73.89858091,
+      40.86165512
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "900 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-127716",
+    "coordinates": [
+      -73.95080928,
+      40.66734613
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "126 SMITH STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-127278",
+    "coordinates": [
+      -73.99002262,
+      40.6874966
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "301 WEST 30 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-108137",
+    "coordinates": [
+      -73.99552538,
+      40.74982748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4037 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120746",
+    "coordinates": [
+      -73.9393767,
+      40.8423372
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "302 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136688",
+    "coordinates": [
+      -73.98593572,
+      40.74671976
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "321 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145870",
+    "coordinates": [
+      -73.99541762,
+      40.68317963
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "97-20 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-143998",
+    "coordinates": [
+      -73.8478444,
+      40.69469686
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 NORTH 5 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146000",
+    "coordinates": [
+      -73.96030116,
+      40.71765823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-06 GREENPOINT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-124993",
+    "coordinates": [
+      -73.91968964,
+      40.74184571
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1970 VICTORY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "si-01-150744",
+    "coordinates": [
+      -74.1301262,
+      40.612231
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "531 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-111683",
+    "coordinates": [
+      -73.99684066,
+      40.73756051
+    ]
+  },
+  {
+    "street_address": "2190 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119988",
+    "coordinates": [
+      -73.95426274,
+      40.80579247
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "125-21 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-123880",
+    "coordinates": [
+      -73.7663874,
+      40.6821457
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1221 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121759",
+    "coordinates": [
+      -73.96223547,
+      40.7636906
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "9 WEST 183 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-111272",
+    "coordinates": [
+      -73.9043559,
+      40.8585715
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "364 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134533",
+    "coordinates": [
+      -73.98160829,
+      40.7367472
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2265 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120248",
+    "coordinates": [
+      -73.93646798,
+      40.80263697
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "132-20 BELKNAP STREET",
+    "type": "LINK1.0",
+    "id": "qu-12-156203",
+    "coordinates": [
+      -73.7579075,
+      40.6762884
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "764 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135163",
+    "coordinates": [
+      -73.99085201,
+      40.76578851
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "144-76 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-07-138935",
+    "coordinates": [
+      -73.8204772,
+      40.7649062
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "797 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121824",
+    "coordinates": [
+      -73.97103228,
+      40.75523348
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2734 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-119762",
+    "coordinates": [
+      -73.8959998,
+      40.8690803
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "302 WEST 37 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-122567",
+    "coordinates": [
+      -73.99233961,
+      40.75413992
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "2321 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-137182",
+    "coordinates": [
+      -73.94264858,
+      40.81644556
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51-04 VERNON BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-125016",
+    "coordinates": [
+      -73.95447974,
+      40.74188244
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1662 ST NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-118142",
+    "coordinates": [
+      -73.9275763,
+      40.8572124
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2083 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145736",
+    "coordinates": [
+      -74.10065158,
+      40.57963412
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2780 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134388",
+    "coordinates": [
+      -73.967585,
+      40.802298
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "72-01 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-143034",
+    "coordinates": [
+      -73.89344842,
+      40.74670669
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1999 UNIVERSITY AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119566",
+    "coordinates": [
+      -73.911439,
+      40.854764
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-136651",
+    "coordinates": [
+      -73.927493,
+      40.751953
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2077 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-108166",
+    "coordinates": [
+      -73.98217819,
+      40.77860683
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1630 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145835",
+    "coordinates": [
+      -74.10090436,
+      40.58990771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1011 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120641",
+    "coordinates": [
+      -73.96108153,
+      40.80149765
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "621 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121103",
+    "coordinates": [
+      -73.97298135,
+      40.79030079
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "92 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123149",
+    "coordinates": [
+      -73.98941209,
+      40.73414056
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "252 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-126392",
+    "coordinates": [
+      -73.9945262,
+      40.68538976
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "178 BOWERY",
+    "type": "LINK1.0",
+    "id": "mn-02-100727",
+    "coordinates": [
+      -73.99407509,
+      40.72059636
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "28 EAST 30 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-144509",
+    "coordinates": [
+      -73.984639,
+      40.745126
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "602 WEST 112 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120269",
+    "coordinates": [
+      -73.96605183,
+      40.80551623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 55 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121798",
+    "coordinates": [
+      -73.97036918,
+      40.7598074
+    ]
+  },
+  {
+    "street_address": "815 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122598",
+    "coordinates": [
+      -73.986606,
+      40.761816
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "571 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122265",
+    "coordinates": [
+      -73.99605667,
+      40.73863995
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "120 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123547",
+    "coordinates": [
+      -73.998106,
+      40.737805
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145774",
+    "coordinates": [
+      -73.87270949,
+      40.73388902
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1325 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-128748",
+    "coordinates": [
+      -73.958697,
+      40.772144
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "130 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-137138",
+    "coordinates": [
+      -73.98452873,
+      40.74575598
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "168-06 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141553",
+    "coordinates": [
+      -73.79220518,
+      40.70635736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "962 EAST 167 STREET",
+    "type": "LINK1.0",
+    "id": "bx-02-119044",
+    "coordinates": [
+      -73.8916437,
+      40.8267141
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "157 EMPIRE BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-157487",
+    "coordinates": [
+      -73.9570101,
+      40.663619
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1463 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120658",
+    "coordinates": [
+      -73.93287,
+      40.850683
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2396 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133629",
+    "coordinates": [
+      -73.975391,
+      40.789424
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "164 EAST 37 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138165",
+    "coordinates": [
+      -73.976965,
+      40.747672
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "184 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-107976",
+    "coordinates": [
+      -74.0067043,
+      40.748842
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "628 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127034",
+    "coordinates": [
+      -73.949916,
+      40.676976
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 EAST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119749",
+    "coordinates": [
+      -73.89719293,
+      40.86732884
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1139 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145784",
+    "coordinates": [
+      -73.95620126,
+      40.68131525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "699 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122095",
+    "coordinates": [
+      -73.98663358,
+      40.75663815
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3647 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134699",
+    "coordinates": [
+      -73.948201,
+      40.829809
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "371 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134564",
+    "coordinates": [
+      -73.98186157,
+      40.73675561
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "771 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-139205",
+    "coordinates": [
+      -73.98751478,
+      40.76056304
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82-02 LEFFERTS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-09-145987",
+    "coordinates": [
+      -73.83136082,
+      40.70753055
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "54 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123820",
+    "coordinates": [
+      -73.989698,
+      40.725641
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70 CHAMBERS STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-123041",
+    "coordinates": [
+      -74.0065117,
+      40.71420865
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "260 WEST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-139276",
+    "coordinates": [
+      -73.985061,
+      40.763424
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2029 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-140140",
+    "coordinates": [
+      -73.98232347,
+      40.77662556
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "217 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-145854",
+    "coordinates": [
+      -73.92866453,
+      40.81225338
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "569 WILSON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-127489",
+    "coordinates": [
+      -73.908632,
+      40.6910423
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 142 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120359",
+    "coordinates": [
+      -73.952134,
+      40.824578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "880 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-139110",
+    "coordinates": [
+      -73.96943631,
+      40.75785145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 57 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121772",
+    "coordinates": [
+      -73.96516242,
+      40.75914915
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-10 LEFFERTS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-09-124790",
+    "coordinates": [
+      -73.83093211,
+      40.69984112
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "530 EAST 138 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-146060",
+    "coordinates": [
+      -73.91834301,
+      40.80710778
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "311 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-140358",
+    "coordinates": [
+      -74.00421615,
+      40.7529434
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "56 KING STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123590",
+    "coordinates": [
+      -74.00523226,
+      40.72780341
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "490 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121437",
+    "coordinates": [
+      -73.978561,
+      40.740894
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1750 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-146095",
+    "coordinates": [
+      -73.91213693,
+      40.84779956
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2820 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-120400",
+    "coordinates": [
+      -73.966917,
+      40.803579
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "811 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122221",
+    "coordinates": [
+      -73.99071175,
+      40.74598929
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1725 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122532",
+    "coordinates": [
+      -73.98236264,
+      40.76467196
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2430 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119941",
+    "coordinates": [
+      -73.94101785,
+      40.8192929
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "784 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-141621",
+    "coordinates": [
+      -73.998822,
+      40.659902
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3450 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145939",
+    "coordinates": [
+      -73.86830879,
+      40.68470155
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "147 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133338",
+    "coordinates": [
+      -73.986488,
+      40.734031
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "49-01 43 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-154903",
+    "coordinates": [
+      -73.9154721,
+      40.744716
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2711 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119896",
+    "coordinates": [
+      -73.94244453,
+      40.8223078
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "68 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121491",
+    "coordinates": [
+      -73.98376711,
+      40.7410117
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "31-90 STEINWAY STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-125145",
+    "coordinates": [
+      -73.91894987,
+      40.759169
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "34-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-102099",
+    "coordinates": [
+      -73.930399,
+      40.744278
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43 NORTH 11 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146018",
+    "coordinates": [
+      -73.9592022,
+      40.72250424
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-137333",
+    "coordinates": [
+      -74.00173929,
+      40.71724104
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "180 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134553",
+    "coordinates": [
+      -73.99679984,
+      40.74269967
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "482 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123611",
+    "coordinates": [
+      -74.00641536,
+      40.73230778
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "401 EAST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121671",
+    "coordinates": [
+      -73.96672853,
+      40.75254917
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33-09 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-145922",
+    "coordinates": [
+      -73.923341,
+      40.761089
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "169 BOWERY",
+    "type": "LINK1.0",
+    "id": "mn-03-108589",
+    "coordinates": [
+      -73.99406649,
+      40.71990707
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "821 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122657",
+    "coordinates": [
+      -73.981711,
+      40.763036
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "245 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123359",
+    "coordinates": [
+      -73.994986,
+      40.744815
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3501 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-135619",
+    "coordinates": [
+      -73.95148795,
+      40.82531855
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-02-125833",
+    "coordinates": [
+      -73.98086659,
+      40.68521833
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2376 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-143395",
+    "coordinates": [
+      -73.94207451,
+      40.81782145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "220 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-139034",
+    "coordinates": [
+      -73.98284709,
+      40.73076722
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "102-61 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124793",
+    "coordinates": [
+      -73.84311,
+      40.695248
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 48 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121790",
+    "coordinates": [
+      -73.969261,
+      40.753496
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3524 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-126233",
+    "coordinates": [
+      -73.9439693,
+      40.65104682
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "88 NORMAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-143275",
+    "coordinates": [
+      -73.951496,
+      40.725456
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "241 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133818",
+    "coordinates": [
+      -73.98123607,
+      40.74998234
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "14 EAST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-123292",
+    "coordinates": [
+      -73.98813578,
+      40.74083617
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "267 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123661",
+    "coordinates": [
+      -73.994537,
+      40.745448
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2440 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-145963",
+    "coordinates": [
+      -73.90430067,
+      40.67786155
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25 EAST 116 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-120180",
+    "coordinates": [
+      -73.94496616,
+      40.80014153
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2350 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-107814",
+    "coordinates": [
+      -73.97655103,
+      40.78800168
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "236 WEST 81 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121239",
+    "coordinates": [
+      -73.97880715,
+      40.78502125
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2460 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145944",
+    "coordinates": [
+      -73.90299005,
+      40.67789498
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "138-02 FARMERS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-158710",
+    "coordinates": [
+      -73.7641959,
+      40.6726629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "42-02 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125116",
+    "coordinates": [
+      -73.913259,
+      40.763
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "50 EAST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121058",
+    "coordinates": [
+      -73.95872117,
+      40.78071593
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "252 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-133655",
+    "coordinates": [
+      -73.99852935,
+      40.74503873
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "232 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133558",
+    "coordinates": [
+      -73.9815598,
+      40.74983207
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1579 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-145925",
+    "coordinates": [
+      -73.91496083,
+      40.84425807
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "442 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121445",
+    "coordinates": [
+      -73.97976183,
+      40.73925317
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "219 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145877",
+    "coordinates": [
+      -73.99378509,
+      40.68657135
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-120024",
+    "coordinates": [
+      -73.94583035,
+      40.80781772
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "152-21 ROCKAWAY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-124531",
+    "coordinates": [
+      -73.7845002,
+      40.6716896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1786 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-107836",
+    "coordinates": [
+      -73.947944,
+      40.787309
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2991 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123217",
+    "coordinates": [
+      -73.91424246,
+      40.81886036
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3823 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-111616",
+    "coordinates": [
+      -73.944011,
+      40.835546
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "99-40 67 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-06-145847",
+    "coordinates": [
+      -73.853929,
+      40.726695
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "605 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121364",
+    "coordinates": [
+      -73.975648,
+      40.748914
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "139 WEST END AVENUE",
+    "type": "Public Payphones",
+    "id": "mn-07-121379",
+    "coordinates": [
+      -73.9872827,
+      40.77617732
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "505 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136691",
+    "coordinates": [
+      -73.99294717,
+      40.75310732
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 70 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120982",
+    "coordinates": [
+      -73.96138086,
+      40.76842289
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43-40 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-145954",
+    "coordinates": [
+      -73.91840166,
+      40.75364064
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "31-14 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-130522",
+    "coordinates": [
+      -73.92485555,
+      40.76164578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "153 WEST 69 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-133487",
+    "coordinates": [
+      -73.98242959,
+      40.77647319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1895 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-146042",
+    "coordinates": [
+      -73.94344594,
+      40.83074624
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "52 EAST 161 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119160",
+    "coordinates": [
+      -73.92590252,
+      40.82755199
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2440 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121255",
+    "coordinates": [
+      -73.97430229,
+      40.79090129
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "572 WEST 139 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120419",
+    "coordinates": [
+      -73.953007,
+      40.822495
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "741 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145754",
+    "coordinates": [
+      -73.95956788,
+      40.65470433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "411 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134922",
+    "coordinates": [
+      -73.980371,
+      40.742433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "522 MORRIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-116415",
+    "coordinates": [
+      -73.92295481,
+      40.81675132
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "639 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121527",
+    "coordinates": [
+      -73.974741,
+      40.750156
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "151 NAGLE AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-131054",
+    "coordinates": [
+      -73.9258525,
+      40.8610939
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43 NORTH 10 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146041",
+    "coordinates": [
+      -73.95977484,
+      40.72194342
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "939 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133436",
+    "coordinates": [
+      -73.96756751,
+      40.76000519
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1739 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120576",
+    "coordinates": [
+      -73.94695314,
+      40.82594748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "395 FLATBUSH AVENUE EXTENSION",
+    "type": "LINK1.0",
+    "id": "bk-02-126433",
+    "coordinates": [
+      -73.980862,
+      40.689026
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "799 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145886",
+    "coordinates": [
+      -73.999532,
+      40.658808
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "969 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122503",
+    "coordinates": [
+      -73.98309182,
+      40.76663812
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1232 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145732",
+    "coordinates": [
+      -74.08382835,
+      40.59771508
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33-20 31 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146039",
+    "coordinates": [
+      -73.921267,
+      40.763207
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "123-08 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145912",
+    "coordinates": [
+      -73.82709687,
+      40.70063483
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4220 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-134446",
+    "coordinates": [
+      -73.9367971,
+      40.8490401
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1320 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-135082",
+    "coordinates": [
+      -73.95646462,
+      40.76695173
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "62-10 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-138662",
+    "coordinates": [
+      -73.90009406,
+      40.75391039
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "410 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134281",
+    "coordinates": [
+      -73.97518371,
+      40.78253997
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3407 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111128",
+    "coordinates": [
+      -73.953676,
+      40.822319
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2292 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-143675",
+    "coordinates": [
+      -73.93610685,
+      40.80351567
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "615 CARROLL STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145895",
+    "coordinates": [
+      -73.981469,
+      40.675254
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "24 EAST 32 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121640",
+    "coordinates": [
+      -73.98409911,
+      40.7465113
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "548 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145909",
+    "coordinates": [
+      -73.991789,
+      40.666904
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "312 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-138789",
+    "coordinates": [
+      -73.92143417,
+      40.81089649
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 WEST 100 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120524",
+    "coordinates": [
+      -73.96864684,
+      40.79673748
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "219 WEST 100 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120510",
+    "coordinates": [
+      -73.9696072,
+      40.79714851
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 WEST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119613",
+    "coordinates": [
+      -73.90750182,
+      40.85393036
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "326 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-140788",
+    "coordinates": [
+      -73.944206,
+      40.713913
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "162 EAST 55 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121842",
+    "coordinates": [
+      -73.968727,
+      40.758993
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "440 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-122031",
+    "coordinates": [
+      -73.980768,
+      40.730496
+    ]
+  },
+  {
+    "street_address": "848 HUNTS POINT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-118973",
+    "coordinates": [
+      -73.8884619,
+      40.8176553
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "123 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134727",
+    "coordinates": [
+      -73.99799948,
+      40.74068566
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2620 BRIGGS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-145853",
+    "coordinates": [
+      -73.8928,
+      40.86487
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-99 84 STREET",
+    "type": "LINK1.0",
+    "id": "qu-03-139600",
+    "coordinates": [
+      -73.8820337,
+      40.74799093
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "830 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122593",
+    "coordinates": [
+      -73.985923,
+      40.762331
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38-02 35 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145986",
+    "coordinates": [
+      -73.92244782,
+      40.7552199
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2130 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133406",
+    "coordinates": [
+      -73.98117276,
+      40.78082575
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "517 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121267",
+    "coordinates": [
+      -73.97262871,
+      40.78568185
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1901 WASHINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-118922",
+    "coordinates": [
+      -73.89822056,
+      40.84692617
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "457 KNICKERBOCKER AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-04-142063",
+    "coordinates": [
+      -73.9184652,
+      40.6989379
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "96-01 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145883",
+    "coordinates": [
+      -73.84858743,
+      40.69467595
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1981 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-135046",
+    "coordinates": [
+      -73.982388,
+      40.774913
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23-24 45 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145781",
+    "coordinates": [
+      -73.94413828,
+      40.74663918
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "21-34 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-142694",
+    "coordinates": [
+      -73.93059918,
+      40.76453793
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "250 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145821",
+    "coordinates": [
+      -73.93040028,
+      40.81359474
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "88-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-142877",
+    "coordinates": [
+      -73.87546,
+      40.734923
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "412 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134654",
+    "coordinates": [
+      -73.98045937,
+      40.742736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4201 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-146096",
+    "coordinates": [
+      -73.89639316,
+      40.84647676
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "73 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-108323",
+    "coordinates": [
+      -73.98935062,
+      40.72647126
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1648 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-113582",
+    "coordinates": [
+      -73.92841499,
+      40.85642084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2120 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-10-118276",
+    "coordinates": [
+      -73.95600349,
+      40.8033996
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "203 EAST 45 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121358",
+    "coordinates": [
+      -73.97284287,
+      40.75266482
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1375 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122057",
+    "coordinates": [
+      -73.98757374,
+      40.75233922
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2048 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120469",
+    "coordinates": [
+      -73.940075,
+      40.835729
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-89 PARSONS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-153718",
+    "coordinates": [
+      -73.8022297,
+      40.7069302
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "610 MELROSE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146066",
+    "coordinates": [
+      -73.91707813,
+      40.81737983
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141 EAST 44 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138038",
+    "coordinates": [
+      -73.97471723,
+      40.75263649
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2022 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-134604",
+    "coordinates": [
+      -73.95025609,
+      40.80662994
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2600 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133639",
+    "coordinates": [
+      -73.97059943,
+      40.79599586
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23-55 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125092",
+    "coordinates": [
+      -73.92851391,
+      40.76355288
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "215 WEST 76 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121223",
+    "coordinates": [
+      -73.98080903,
+      40.78170535
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1003 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-137419",
+    "coordinates": [
+      -73.96127853,
+      40.80124724
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "401 EAST 12 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-139623",
+    "coordinates": [
+      -73.9832813,
+      40.72996268
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2242 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121228",
+    "coordinates": [
+      -73.979224,
+      40.784564
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "220 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123538",
+    "coordinates": [
+      -74.0009461,
+      40.73899661
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "407 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-134631",
+    "coordinates": [
+      -73.9838785,
+      40.74339468
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "79 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-145996",
+    "coordinates": [
+      -73.96424309,
+      40.71573175
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "136-39 SPRINGFIELD BLVD",
+    "type": "LINK1.0",
+    "id": "qu-12-156367",
+    "coordinates": [
+      -73.7556543,
+      40.6766671
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "22 EAST 69 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121142",
+    "coordinates": [
+      -73.96676342,
+      40.76974939
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "399 EAST 72 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120843",
+    "coordinates": [
+      -73.95569057,
+      40.76777013
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "97-14 66 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-06-145765",
+    "coordinates": [
+      -73.85607116,
+      40.72748901
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "800 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-137461",
+    "coordinates": [
+      -73.98993307,
+      40.76704736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2454 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119884",
+    "coordinates": [
+      -73.94791958,
+      40.81444736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "36-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-142874",
+    "coordinates": [
+      -73.921216,
+      40.760095
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "135 EAST 146 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-145819",
+    "coordinates": [
+      -73.92888643,
+      40.81751219
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "76-22 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-137796",
+    "coordinates": [
+      -73.8888199,
+      40.74705911
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-15 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-111054",
+    "coordinates": [
+      -73.87871569,
+      40.74825267
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "216 WEST 89 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-133391",
+    "coordinates": [
+      -73.974767,
+      40.790053
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "327 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123656",
+    "coordinates": [
+      -73.99712687,
+      40.74737717
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "397 EAST 54 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138509",
+    "coordinates": [
+      -73.96397801,
+      40.75629836
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "218 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-10-102771",
+    "coordinates": [
+      -73.95278868,
+      40.80732567
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-20 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145884",
+    "coordinates": [
+      -73.85056916,
+      40.69414034
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "238 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-108509",
+    "coordinates": [
+      -73.998736,
+      40.74475
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "38-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-124955",
+    "coordinates": [
+      -73.92692611,
+      40.74387741
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121787",
+    "coordinates": [
+      -73.96746716,
+      40.75601841
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4080 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120797",
+    "coordinates": [
+      -73.9388952,
+      40.8439944
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "226 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123803",
+    "coordinates": [
+      -73.98610741,
+      40.73274736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2220 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121229",
+    "coordinates": [
+      -73.979708,
+      40.78392
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "445 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125626",
+    "coordinates": [
+      -73.986317,
+      40.669018
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2601 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133638",
+    "coordinates": [
+      -73.970931,
+      40.796138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1700 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119829",
+    "coordinates": [
+      -73.94987392,
+      40.78466254
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "553 GRAND STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-123340",
+    "coordinates": [
+      -73.9802017,
+      40.7139606
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "123-32 82 AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-09-124174",
+    "coordinates": [
+      -73.8277241,
+      40.7126534
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "551 WEST 138 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120422",
+    "coordinates": [
+      -73.95331,
+      40.821918
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-06 126 STREET",
+    "type": "LINK1.0",
+    "id": "qu-09-138287",
+    "coordinates": [
+      -73.824719,
+      40.70104
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "974 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133433",
+    "coordinates": [
+      -73.96707578,
+      40.76109516
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1659 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-134420",
+    "coordinates": [
+      -73.94901382,
+      40.82312201
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4 WEST 51 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122867",
+    "coordinates": [
+      -73.97699037,
+      40.7592052
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-01 STEINWAY STREET",
+    "type": "LINK1.0",
+    "id": "qu-01-125148",
+    "coordinates": [
+      -73.91505124,
+      40.76368606
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-126659",
+    "coordinates": [
+      -73.94209,
+      40.70099
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1031 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-134750",
+    "coordinates": [
+      -73.965443,
+      40.762896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2848 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134415",
+    "coordinates": [
+      -73.96632817,
+      40.80439875
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "127 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135620",
+    "coordinates": [
+      -74.00150114,
+      40.74137338
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "56 LAFAYETTE AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-02-126807",
+    "coordinates": [
+      -73.97637079,
+      40.68696059
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2401 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-137385",
+    "coordinates": [
+      -73.941152,
+      40.818505
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "321 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145893",
+    "coordinates": [
+      -73.98316142,
+      40.6726791
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "541 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134845",
+    "coordinates": [
+      -73.97715884,
+      40.74685005
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121490",
+    "coordinates": [
+      -73.982886,
+      40.738827
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "199 EAST 25 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138462",
+    "coordinates": [
+      -73.982383,
+      40.740246
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1280 OAK POINT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-152493",
+    "coordinates": [
+      -73.886431,
+      40.8103727
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3778 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-120450",
+    "coordinates": [
+      -73.94477152,
+      40.83391054
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "28-11 ASTORIA BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-146090",
+    "coordinates": [
+      -73.92035427,
+      40.77074708
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "976 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121684",
+    "coordinates": [
+      -73.96418188,
+      40.7562636
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1341 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-134789",
+    "coordinates": [
+      -73.93565287,
+      40.84687477
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163-33 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141540",
+    "coordinates": [
+      -73.795897,
+      40.705143
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "487 EAST 156 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-118947",
+    "coordinates": [
+      -73.91283823,
+      40.82010249
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST FORDHAM ROAD",
+    "type": "LINK1.0",
+    "id": "bx-05-119635",
+    "coordinates": [
+      -73.8948269,
+      40.8619052
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "18 DELANCEY STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-107871",
+    "coordinates": [
+      -73.99306771,
+      40.72018834
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1175 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120988",
+    "coordinates": [
+      -73.96228982,
+      40.76723406
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "104 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123273",
+    "coordinates": [
+      -73.98837167,
+      40.72745986
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "82-61 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-124856",
+    "coordinates": [
+      -73.88106477,
+      40.74199055
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "230 WEST 79 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-133623",
+    "coordinates": [
+      -73.97975218,
+      40.78364875
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "237 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123802",
+    "coordinates": [
+      -73.982827,
+      40.73121904
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2598 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145937",
+    "coordinates": [
+      -73.89835842,
+      40.67699412
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3197 BAINBRIDGE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-144266",
+    "coordinates": [
+      -73.8796537,
+      40.8757421
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "115 NORTH 6 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146013",
+    "coordinates": [
+      -73.95968841,
+      40.718187
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "179 WEST 26 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-123662",
+    "coordinates": [
+      -73.99403913,
+      40.74596848
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1313 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122775",
+    "coordinates": [
+      -73.98779173,
+      40.75009208
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2282 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121302",
+    "coordinates": [
+      -73.97829312,
+      40.78581305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "578 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121521",
+    "coordinates": [
+      -73.9763443,
+      40.74838329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1918 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120224",
+    "coordinates": [
+      -73.94489482,
+      40.79148064
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100-26 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-145846",
+    "coordinates": [
+      -73.853138,
+      40.726495
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "944 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122622",
+    "coordinates": [
+      -73.98336787,
+      40.76582962
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 86 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-133368",
+    "coordinates": [
+      -73.953663,
+      40.778792
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "142-82 ROCKAWAY BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-124543",
+    "coordinates": [
+      -73.7957959,
+      40.6733107
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 MONTGOMERY STREET",
+    "type": "LINK1.0",
+    "id": "bk-09-153615",
+    "coordinates": [
+      -73.9595776,
+      40.6664152
+    ]
+  },
+  {
+    "street_address": "400 EAST TREMONT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-119378",
+    "coordinates": [
+      -73.90076644,
+      40.8475737
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "340 EMPIRE BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bk-09-126475",
+    "coordinates": [
+      -73.95077465,
+      40.66382689
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "27-35 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-145926",
+    "coordinates": [
+      -73.93995198,
+      40.7481039
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "66 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-137104",
+    "coordinates": [
+      -73.98857914,
+      40.73157049
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "110-44 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124180",
+    "coordinates": [
+      -73.839741,
+      40.719293
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "715 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-134709",
+    "coordinates": [
+      -73.9681904,
+      40.7917631
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1439 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111623",
+    "coordinates": [
+      -73.93347331,
+      40.84985449
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "375 EAST 188 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-119659",
+    "coordinates": [
+      -73.893343,
+      40.860027
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "370 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134618",
+    "coordinates": [
+      -73.98151176,
+      40.74129079
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2820 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145728",
+    "coordinates": [
+      -74.116075,
+      40.563843
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1500 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-111948",
+    "coordinates": [
+      -73.952755,
+      40.818371
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "185-11 140 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-153879",
+    "coordinates": [
+      -73.7591625,
+      40.6725729
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1803 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-126644",
+    "coordinates": [
+      -73.927098,
+      40.679232
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "210 WEST 101 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120395",
+    "coordinates": [
+      -73.96924393,
+      40.79770166
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "74-39 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-126735",
+    "coordinates": [
+      -73.866734,
+      40.69145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "216 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146086",
+    "coordinates": [
+      -73.92333228,
+      40.80829273
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98 KING STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123606",
+    "coordinates": [
+      -74.00698658,
+      40.72797798
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "245 PARK AVENUE SOUTH",
+    "type": "LINK1.0",
+    "id": "mn-05-137241",
+    "coordinates": [
+      -73.9877384,
+      40.73809688
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1580 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120663",
+    "coordinates": [
+      -73.92992035,
+      40.85435846
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "203 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-122344",
+    "coordinates": [
+      -73.99663087,
+      40.71903975
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2260 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119944",
+    "coordinates": [
+      -73.944756,
+      40.814156
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "907 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-145747",
+    "coordinates": [
+      -73.967093,
+      40.683591
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "104-13 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-104094",
+    "coordinates": [
+      -73.84283995,
+      40.6952564
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 EAST 204 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-119718",
+    "coordinates": [
+      -73.8786393,
+      40.8729442
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "271 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-125716",
+    "coordinates": [
+      -73.97406,
+      40.679568
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "747 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122475",
+    "coordinates": [
+      -73.99149319,
+      40.76527687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "43-02 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-142124",
+    "coordinates": [
+      -73.921257,
+      40.743221
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "590 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-107815",
+    "coordinates": [
+      -73.9738668,
+      40.78944465
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "404 NEW DORP LANE",
+    "type": "LINK1.0",
+    "id": "si-02-125463",
+    "coordinates": [
+      -74.10965729,
+      40.57031185
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "715 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-135658",
+    "coordinates": [
+      -73.97089386,
+      40.79316136
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "46-01 58 STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-145787",
+    "coordinates": [
+      -73.90753416,
+      40.74143396
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "75-32 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-04-145900",
+    "coordinates": [
+      -73.88945075,
+      40.74576092
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "323 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121488",
+    "coordinates": [
+      -73.982489,
+      40.739528
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-50 44 Drive",
+    "type": "LINK1.0",
+    "id": "qu-02-146061",
+    "coordinates": [
+      -73.949855,
+      40.748497
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "727 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122766",
+    "coordinates": [
+      -73.99250826,
+      40.74351013
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "69 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134468",
+    "coordinates": [
+      -73.99342438,
+      40.73611052
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-137165",
+    "coordinates": [
+      -74.000962,
+      40.717828
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 ORCHARD STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-108607",
+    "coordinates": [
+      -73.991198,
+      40.716355
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "56 WEST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119874",
+    "coordinates": [
+      -73.8995757,
+      40.86782871
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2002 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111803",
+    "coordinates": [
+      -73.94115905,
+      40.83424538
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1191 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121758",
+    "coordinates": [
+      -73.96268514,
+      40.76307964
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3421 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-135705",
+    "coordinates": [
+      -73.95329055,
+      40.82285389
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "260 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-143655",
+    "coordinates": [
+      -74.0051459,
+      40.75123392
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48-18 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-145956",
+    "coordinates": [
+      -73.91450114,
+      40.7535215
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "355 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121209",
+    "coordinates": [
+      -73.97913747,
+      40.78186119
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "402 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-133689",
+    "coordinates": [
+      -73.99511,
+      40.749728
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "737 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145832",
+    "coordinates": [
+      -73.9502139,
+      40.67211449
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "850 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-137822",
+    "coordinates": [
+      -73.97059306,
+      40.75183416
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "344 EAST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-138568",
+    "coordinates": [
+      -73.96139743,
+      40.76094634
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1245 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145739",
+    "coordinates": [
+      -73.951381,
+      40.680556
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "765 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120525",
+    "coordinates": [
+      -73.969254,
+      40.795399
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1617 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-146100",
+    "coordinates": [
+      -74.10092195,
+      40.59045311
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1026 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121692",
+    "coordinates": [
+      -73.96321332,
+      40.75770122
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1495 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121021",
+    "coordinates": [
+      -73.954752,
+      40.777561
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "83 WEST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-10-123361",
+    "coordinates": [
+      -73.945253,
+      40.807779
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "816 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-133672",
+    "coordinates": [
+      -73.968682,
+      40.796533
+    ]
+  },
+  {
+    "street_address": "1025 East 163rd Street",
+    "type": "LINK1.0",
+    "id": "bx-02-111546",
+    "coordinates": [
+      -73.8921302,
+      40.8210579
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "910 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122619",
+    "coordinates": [
+      -73.98409944,
+      40.76482318
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3536 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-111651",
+    "coordinates": [
+      -73.950482,
+      40.82609
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "84-29 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-136453",
+    "coordinates": [
+      -73.88138742,
+      40.74797068
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "700 RICHMOND TERRACE",
+    "type": "LINK1.0",
+    "id": "si-01-152835",
+    "coordinates": [
+      -74.0954559,
+      40.6448114
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29-19 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125084",
+    "coordinates": [
+      -73.926262,
+      40.762464
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "10-63 JACKSON AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-125014",
+    "coordinates": [
+      -73.95212666,
+      40.74291934
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "100 WEST 28 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-108540",
+    "coordinates": [
+      -73.99079235,
+      40.74611567
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "161 EAST 27 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-136126",
+    "coordinates": [
+      -73.98148039,
+      40.74148709
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "150-05 LIBERTY AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-118519",
+    "coordinates": [
+      -73.802253,
+      40.6980506
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2618 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133628",
+    "coordinates": [
+      -73.97027901,
+      40.79642525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2001 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142515",
+    "coordinates": [
+      -73.950407,
+      40.805827
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3816 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-111556",
+    "coordinates": [
+      -73.943873,
+      40.835135
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 WEST 83 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-136212",
+    "coordinates": [
+      -73.977698,
+      40.786207
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "323 GRAND STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-122371",
+    "coordinates": [
+      -73.99058102,
+      40.71709475
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "621 WEST END AVENUE",
+    "type": "Public Payphones",
+    "id": "mn-07-121406",
+    "coordinates": [
+      -73.97602374,
+      40.79157583
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-123535",
+    "coordinates": [
+      -73.99831928,
+      40.73807416
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "767 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121418",
+    "coordinates": [
+      -73.97275057,
+      40.74929182
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1515 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122096",
+    "coordinates": [
+      -73.98570283,
+      40.75786907
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 80 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121015",
+    "coordinates": [
+      -73.956665,
+      40.774855
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "601 WEST 178 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-139589",
+    "coordinates": [
+      -73.93536309,
+      40.84751332
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "705 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121426",
+    "coordinates": [
+      -73.97424149,
+      40.74725106
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "317 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-01-123044",
+    "coordinates": [
+      -74.005126,
+      40.715712
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "718 EAST 149 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-119027",
+    "coordinates": [
+      -73.90899141,
+      40.81312832
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 WEST 139 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120370",
+    "coordinates": [
+      -73.95349829,
+      40.82270396
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2276 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-143295",
+    "coordinates": [
+      -73.97843851,
+      40.78561298
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1609 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-134155",
+    "coordinates": [
+      -73.98463363,
+      40.7607176
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2754 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145738",
+    "coordinates": [
+      -74.115318,
+      40.564789
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "259 WEST 24 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-139167",
+    "coordinates": [
+      -73.99775661,
+      40.74592407
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1976 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120460",
+    "coordinates": [
+      -73.94174,
+      40.833447
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "186 EAST 125 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-144674",
+    "coordinates": [
+      -73.93635101,
+      40.80383418
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 WYTHE AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-146010",
+    "coordinates": [
+      -73.96047431,
+      40.71940433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "90-20 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145768",
+    "coordinates": [
+      -73.871648,
+      40.733579
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2606 SNYDER AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-145979",
+    "coordinates": [
+      -73.952414,
+      40.648733
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "188 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133521",
+    "coordinates": [
+      -73.98584567,
+      40.73534819
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "984 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145863",
+    "coordinates": [
+      -73.954581,
+      40.732735
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2878 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134690",
+    "coordinates": [
+      -73.96566952,
+      40.80527964
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "562 WEST 113 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-120408",
+    "coordinates": [
+      -73.965081,
+      40.805923
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 EAST 25 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-103457",
+    "coordinates": [
+      -73.98203484,
+      40.7399752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "633 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-135586",
+    "coordinates": [
+      -73.97510442,
+      40.74965755
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "5022 12TH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-12-126950",
+    "coordinates": [
+      -73.9956001,
+      40.6353697
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "426 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-125921",
+    "coordinates": [
+      -73.98595804,
+      40.66973105
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "523 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-108109",
+    "coordinates": [
+      -73.99256281,
+      40.75364209
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "211 ST. ANN'S AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146053",
+    "coordinates": [
+      -73.91795518,
+      40.80628664
+    ]
+  },
+  {
+    "street_address": "1190 PROSPECT AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-155911",
+    "coordinates": [
+      -73.8985543,
+      40.8264487
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2397 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120309",
+    "coordinates": [
+      -73.93470439,
+      40.80140456
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "948 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125836",
+    "coordinates": [
+      -74.00654892,
+      40.65574578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "115-01 FARMERS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123858",
+    "coordinates": [
+      -73.7612345,
+      40.6959752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "30-20 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125127",
+    "coordinates": [
+      -73.92154563,
+      40.7668938
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33 SOUTH 2 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146085",
+    "coordinates": [
+      -73.96652497,
+      40.71470734
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "147-05 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141535",
+    "coordinates": [
+      -73.807661,
+      40.701827
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1422 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145808",
+    "coordinates": [
+      -73.943843,
+      40.680015
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "55 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138508",
+    "coordinates": [
+      -73.988685,
+      40.731015
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "102-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-03-125402",
+    "coordinates": [
+      -73.86643426,
+      40.75744562
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "875 GERARD AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-113552",
+    "coordinates": [
+      -73.9248328,
+      40.82782471
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "515 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-06-145874",
+    "coordinates": [
+      -73.98837832,
+      40.66653858
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 ELDERT LANE",
+    "type": "LINK1.0",
+    "id": "bk-05-126737",
+    "coordinates": [
+      -73.86809486,
+      40.69102143
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "246 WEST 80 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121312",
+    "coordinates": [
+      -73.97977572,
+      40.78460807
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "49-18 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145741",
+    "coordinates": [
+      -73.91534245,
+      40.74254629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1580 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-139323",
+    "coordinates": [
+      -73.950863,
+      40.82096
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "850 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135877",
+    "coordinates": [
+      -73.98904337,
+      40.76826158
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "8 WEST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-111414",
+    "coordinates": [
+      -73.907899,
+      40.853764
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "31 EAST 26 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121630",
+    "coordinates": [
+      -73.98641999,
+      40.74275953
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "360 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121596",
+    "coordinates": [
+      -73.9770118,
+      40.75027937
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "434 MANHATTAN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-145858",
+    "coordinates": [
+      -73.946853,
+      40.719511
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "716 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121531",
+    "coordinates": [
+      -73.97325385,
+      40.75262285
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1940 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119959",
+    "coordinates": [
+      -73.95213993,
+      40.80404696
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "198-01 HOLLIS AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-124000",
+    "coordinates": [
+      -73.7595318,
+      40.7064807
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "61 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-125630",
+    "coordinates": [
+      -73.942682,
+      40.703654
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-23 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-134084",
+    "coordinates": [
+      -73.87951058,
+      40.74816825
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "65 COURT STREET",
+    "type": "LINK5G_Ad",
+    "id": "BK-02-126840",
+    "coordinates": [
+      -73.9911888,
+      40.69158
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "770 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121813",
+    "coordinates": [
+      -73.97187609,
+      40.75451175
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1221 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120546",
+    "coordinates": [
+      -73.95902951,
+      40.80941222
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1500 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120667",
+    "coordinates": [
+      -73.93177297,
+      40.85183107
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "381 NEW DORP LANE",
+    "type": "LINK1.0",
+    "id": "si-02-125470",
+    "coordinates": [
+      -74.109918,
+      40.570635
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "260 SPRING STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-138004",
+    "coordinates": [
+      -74.00627426,
+      40.725666
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1220 EAST NEW YORK AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-158237",
+    "coordinates": [
+      -73.9220234,
+      40.6673324
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "505 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145837",
+    "coordinates": [
+      -73.949473,
+      40.679987
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "394 KENT AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-146093",
+    "coordinates": [
+      -73.96853381,
+      40.71098811
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "119 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-135652",
+    "coordinates": [
+      -73.99119855,
+      40.73916604
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "931 WESTCHESTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-145554",
+    "coordinates": [
+      -73.8976484,
+      40.8218381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "806 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-126616",
+    "coordinates": [
+      -73.95817186,
+      40.67031776
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 MAPLE STREET",
+    "type": "LINK1.0",
+    "id": "bk-09-150264",
+    "coordinates": [
+      -73.9533079,
+      40.6606157
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "180-01 LINDEN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-151804",
+    "coordinates": [
+      -73.7665646,
+      40.6923012
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 EAST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119592",
+    "coordinates": [
+      -73.905403,
+      40.853157
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "67 READE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-109612",
+    "coordinates": [
+      -74.00677204,
+      40.71502742
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "42-01 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-145951",
+    "coordinates": [
+      -73.91723,
+      40.758221
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "777 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-126832",
+    "coordinates": [
+      -73.95035244,
+      40.67064687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "125 WEST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-122427",
+    "coordinates": [
+      -73.99792058,
+      40.73790583
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2681 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134106",
+    "coordinates": [
+      -73.969093,
+      40.79865
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1331 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-136195",
+    "coordinates": [
+      -73.9565366,
+      40.76728194
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "410 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-137210",
+    "coordinates": [
+      -73.97652976,
+      40.75674218
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2008 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134449",
+    "coordinates": [
+      -73.981973,
+      40.775532
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1161 VICTORY BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "si-01-125525",
+    "coordinates": [
+      -74.1033513,
+      40.6166443
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "74 NAGLE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "mn-12-120807",
+    "coordinates": [
+      -73.9283369,
+      40.8603681
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "876 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120534",
+    "coordinates": [
+      -73.96726529,
+      40.79847664
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "380 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134535",
+    "coordinates": [
+      -73.9813679,
+      40.737088
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "151 EAST FORDHAM Road",
+    "type": "LINK1.0",
+    "id": "bx-07-119568",
+    "coordinates": [
+      -73.8981273,
+      40.8624494
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "197 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121191",
+    "coordinates": [
+      -73.98301515,
+      40.77653006
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2166 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-107943",
+    "coordinates": [
+      -73.9390355,
+      40.79950465
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "6 WEST 32 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-107796",
+    "coordinates": [
+      -73.98618292,
+      40.74739113
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "9 SNYDER AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145949",
+    "coordinates": [
+      -73.95781959,
+      40.64860712
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1280 VIELE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-02-150012",
+    "coordinates": [
+      -73.8852154,
+      40.8066118
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "601 WEST 111 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-134916",
+    "coordinates": [
+      -73.96678806,
+      40.80511381
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "736 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134211",
+    "coordinates": [
+      -73.98401196,
+      40.76023532
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1653 ST NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-118141",
+    "coordinates": [
+      -73.9283674,
+      40.8570315
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1220 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145735",
+    "coordinates": [
+      -74.08305039,
+      40.59800199
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "341 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122453",
+    "coordinates": [
+      -73.992745,
+      40.747904
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "973 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122621",
+    "coordinates": [
+      -73.98285321,
+      40.76696325
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "249 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146024",
+    "coordinates": [
+      -73.92262283,
+      40.80966819
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-18 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136367",
+    "coordinates": [
+      -73.87938648,
+      40.74804918
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "166-01 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-141550",
+    "coordinates": [
+      -73.79375474,
+      40.70599343
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "101 WEST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-134467",
+    "coordinates": [
+      -73.98193,
+      40.773806
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-02-123559",
+    "coordinates": [
+      -74.00350218,
+      40.72711527
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "16 EAST 60 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-137205",
+    "coordinates": [
+      -73.97119784,
+      40.76425414
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "650 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-136969",
+    "coordinates": [
+      -73.971424,
+      40.763742
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "173-20 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-114989",
+    "coordinates": [
+      -73.7859137,
+      40.7078312
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70 WEST 13 STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-122267",
+    "coordinates": [
+      -73.99715554,
+      40.73653988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "147-14 HILLSIDE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-128738",
+    "coordinates": [
+      -73.809058,
+      40.7058192
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "979 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-132668",
+    "coordinates": [
+      -73.963959,
+      40.682932
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "223 EAST 14 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-123287",
+    "coordinates": [
+      -73.98617294,
+      40.7329605
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "675 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134628",
+    "coordinates": [
+      -73.99352183,
+      40.74212565
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "27 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-127080",
+    "coordinates": [
+      -73.97393282,
+      40.68213254
+    ]
+  },
+  {
+    "street_address": "250 WEST 94 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107919",
+    "coordinates": [
+      -73.97304342,
+      40.79342581
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1722 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120218",
+    "coordinates": [
+      -73.94903127,
+      40.78581769
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "527 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121966",
+    "coordinates": [
+      -73.9736332,
+      40.76024945
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1146 EAST NEW YORK AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-156770",
+    "coordinates": [
+      -73.9241733,
+      40.6663933
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "362 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136668",
+    "coordinates": [
+      -73.98173228,
+      40.74098927
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "79-14 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145777",
+    "coordinates": [
+      -73.883978,
+      40.737777
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "113-50 FARMERS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123850",
+    "coordinates": [
+      -73.7624764,
+      40.698178
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 40 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138062",
+    "coordinates": [
+      -73.9748182,
+      40.74930073
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2493 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145945",
+    "coordinates": [
+      -73.90195137,
+      40.67754
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1295 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-127011",
+    "coordinates": [
+      -73.949966,
+      40.65532
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1142 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-115163",
+    "coordinates": [
+      -73.9601529,
+      40.76191027
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "355 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121539",
+    "coordinates": [
+      -73.981729,
+      40.740573
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "178 CANAL STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-133426",
+    "coordinates": [
+      -73.99764592,
+      40.71665239
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1928 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-146077",
+    "coordinates": [
+      -73.9445962,
+      40.79189835
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2271 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145823",
+    "coordinates": [
+      -74.1048165,
+      40.57555318
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "748 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-140000",
+    "coordinates": [
+      -73.99131194,
+      40.76515921
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3559 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-134828",
+    "coordinates": [
+      -73.95022615,
+      40.82704355
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "34-24 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145947",
+    "coordinates": [
+      -73.91836041,
+      40.76540165
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2493 VALENTINE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119638",
+    "coordinates": [
+      -73.89607854,
+      40.86205098
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2901 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-118955",
+    "coordinates": [
+      -73.91620844,
+      40.8171412
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "500 WEST 211TH STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-156294",
+    "coordinates": [
+      -73.9172909,
+      40.8670576
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2482 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133634",
+    "coordinates": [
+      -73.973409,
+      40.792132
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2380 ADAM CLAYTON POWELL JR. BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-134578",
+    "coordinates": [
+      -73.94192414,
+      40.81802907
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "112-01 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124784",
+    "coordinates": [
+      -73.8362804,
+      40.69756287
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "450 WEST 162 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120468",
+    "coordinates": [
+      -73.939589,
+      40.835586
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "104 EAST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119590",
+    "coordinates": [
+      -73.90555222,
+      40.85304298
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1785 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122514",
+    "coordinates": [
+      -73.98185929,
+      40.76700781
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "597 GRAND CONCOURSE",
+    "type": "LINK1.0",
+    "id": "bx-04-140582",
+    "coordinates": [
+      -73.926847,
+      40.819886
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "185 BERRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146001",
+    "coordinates": [
+      -73.96084076,
+      40.71684975
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "604 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121433",
+    "coordinates": [
+      -73.97619,
+      40.744154
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "581B 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121352",
+    "coordinates": [
+      -73.976105,
+      40.748289
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "341 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134921",
+    "coordinates": [
+      -73.98198848,
+      40.74021823
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "459 BERGEN STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145871",
+    "coordinates": [
+      -73.97573017,
+      40.68103872
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1710 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122529",
+    "coordinates": [
+      -73.98230856,
+      40.76412672
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1216 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-126536",
+    "coordinates": [
+      -73.95592439,
+      40.64066623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3435 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-05-145940",
+    "coordinates": [
+      -73.86897453,
+      40.68462509
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "215 WEST 91 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-121254",
+    "coordinates": [
+      -73.973822,
+      40.791401
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "29 SOUTH 3 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-145995",
+    "coordinates": [
+      -73.96693042,
+      40.71391386
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2730 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119893",
+    "coordinates": [
+      -73.941723,
+      40.822924
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "39 EAST 81 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121040",
+    "coordinates": [
+      -73.96094657,
+      40.77760614
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 TEN EYCK STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146047",
+    "coordinates": [
+      -73.95070637,
+      40.70957163
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 124 STREET",
+    "type": "LINK1.0",
+    "id": "mn-11-120242",
+    "coordinates": [
+      -73.93810707,
+      40.80383351
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1407 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122175",
+    "coordinates": [
+      -73.98738603,
+      40.75305908
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2307 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142812",
+    "coordinates": [
+      -73.95184032,
+      40.80943715
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "198 EAST 76 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120999",
+    "coordinates": [
+      -73.95895916,
+      40.77237577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "135 EAST 149 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-119146",
+    "coordinates": [
+      -73.92837,
+      40.818942
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-12 37 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-146069",
     "coordinates": [
       -73.8858319,
       40.74953249
@@ -14944,10 +18767,2327 @@
     "status": "active"
   },
   {
-    "id": "LINK-023349",
+    "street_address": "200 WEST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122656",
     "coordinates": [
-      -73.90854944,
-      40.82392555
+      -73.982552,
+      40.762366
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "650 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-125904",
+    "coordinates": [
+      -73.992259,
+      40.662588
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "204-03 LINDEN BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-123982",
+    "coordinates": [
+      -73.7485326,
+      40.6955453
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2828 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-134385",
+    "coordinates": [
+      -73.96670754,
+      40.80386123
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87-26 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145911",
+    "coordinates": [
+      -73.8564538,
+      40.69260724
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1244 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-142793",
+    "coordinates": [
+      -73.958744,
+      40.810163
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "281 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145918",
+    "coordinates": [
+      -73.99476547,
+      40.68455252
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "32 GRAHAM AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-01-143982",
+    "coordinates": [
+      -73.94223924,
+      40.70193034
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "139 EAST 58 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-143917",
+    "coordinates": [
+      -73.96839056,
+      40.76155923
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "481 WEST 159 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-120458",
+    "coordinates": [
+      -73.940919,
+      40.834078
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "70 WEST BURNSIDE AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-113539",
+    "coordinates": [
+      -73.91021789,
+      40.85434622
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2020 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-121336",
+    "coordinates": [
+      -73.98193739,
+      40.77631103
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "23 EAST 28 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121636",
+    "coordinates": [
+      -73.98542849,
+      40.74396179
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "129-01 GUY R BREWER BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-154934",
+    "coordinates": [
+      -73.7784359,
+      40.6772288
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 WEST 17 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-123023",
+    "coordinates": [
+      -73.9923767,
+      40.73803969
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "33-28 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-01-136650",
+    "coordinates": [
+      -73.929992,
+      40.75191
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1710 EASTERN PARKWAY",
+    "type": "LINK5G_Ad",
+    "id": "bk-16-108732",
+    "coordinates": [
+      -73.9114724,
+      40.6728522
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 WEST 53 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122871",
+    "coordinates": [
+      -73.97609914,
+      40.76047373
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2858 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120396",
+    "coordinates": [
+      -73.965995,
+      40.804835
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1055 EAST 163 STREET",
+    "type": "LINK1.0",
+    "id": "bx-02-119037",
+    "coordinates": [
+      -73.8904576,
+      40.8209142
+    ]
+  },
+  {
+    "street_address": "84 DELANCEY STREET",
+    "type": "LINK1.0",
+    "id": "mn-03-123367",
+    "coordinates": [
+      -73.98985,
+      40.719215
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "575 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136316",
+    "coordinates": [
+      -73.99166162,
+      40.75488084
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "183 CANAL STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-133430",
+    "coordinates": [
+      -73.997578,
+      40.716869
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3723 CHURCH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-17-146003",
+    "coordinates": [
+      -73.94206208,
+      40.65122997
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141 EAST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-135937",
+    "coordinates": [
+      -73.966995,
+      40.763419
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "73-02 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-03-134030",
+    "coordinates": [
+      -73.893639,
+      40.754507
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "794 PROSPECT PLACE",
+    "type": "LINK1.0",
+    "id": "bk-08-127037",
+    "coordinates": [
+      -73.950234,
+      40.674266
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3015 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123216",
+    "coordinates": [
+      -73.91366803,
+      40.81948845
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "560 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-03-145750",
+    "coordinates": [
+      -73.955431,
+      40.679506
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1106 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-127021",
+    "coordinates": [
+      -73.95072664,
+      40.6607318
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "991 NOSTRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-130021",
+    "coordinates": [
+      -73.95091962,
+      40.66416648
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "395 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-01-109252",
+    "coordinates": [
+      -73.95419488,
+      40.70720786
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "177 BRISTOL STREET",
+    "type": "LINK1.0",
+    "id": "bk-16-158984",
+    "coordinates": [
+      -73.9119235,
+      40.6670116
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1369 BROADWAY",
+    "type": "LINK1.0",
+    "id": "bk-04-142023",
+    "coordinates": [
+      -73.9211884,
+      40.6892704
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "382 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136213",
+    "coordinates": [
+      -73.995553,
+      40.749122
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41 EAST 53 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121967",
+    "coordinates": [
+      -73.974008,
+      40.759712
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "91-03 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145984",
+    "coordinates": [
+      -73.853678,
+      40.693166
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1493 MYRTLE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-04-159328",
+    "coordinates": [
+      -73.9159378,
+      40.6992378
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "401 EAST 66 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120956",
+    "coordinates": [
+      -73.95853038,
+      40.76394756
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "251 WEST 93 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-134701",
+    "coordinates": [
+      -73.97344682033187,
+      40.79288708
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "141 LINCOLN AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-145852",
+    "coordinates": [
+      -73.92907378,
+      40.80854426
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "48-19 VERNON BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-141373",
+    "coordinates": [
+      -73.95373886,
+      40.74355856
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1722 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120565",
+    "coordinates": [
+      -73.947604,
+      40.825419
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1952 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-111956",
+    "coordinates": [
+      -73.94226576,
+      40.83273107
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "119 WEST KINGSBRIDGE ROAD",
+    "type": "LINK1.0",
+    "id": "bx-08-145850",
+    "coordinates": [
+      -73.9021009,
+      40.86869849
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1016 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-14-145814",
+    "coordinates": [
+      -73.95820347,
+      40.64617918
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "844 ST. ANN'S AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146065",
+    "coordinates": [
+      -73.90942748,
+      40.82233792
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "320 SCHERMERHORN STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-127256",
+    "coordinates": [
+      -73.9817194,
+      40.68721034
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1273 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122056",
+    "coordinates": [
+      -73.98821846,
+      40.74853941
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "899 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145862",
+    "coordinates": [
+      -74.00305032,
+      40.6554376
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2374 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119606",
+    "coordinates": [
+      -73.902369,
+      40.86063
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "130 WEST 68 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-137400",
+    "coordinates": [
+      -73.98107921,
+      40.77496988
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "63 SHERMAN AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120736",
+    "coordinates": [
+      -73.9269963,
+      40.8631134
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "814 RICHMOND TERRACE",
+    "type": "LINK1.0",
+    "id": "si-01-152115",
+    "coordinates": [
+      -74.0994592,
+      40.6446982
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2084 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119982",
+    "coordinates": [
+      -73.95676156,
+      40.80236833
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "300 WEST 108 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-120267",
+    "coordinates": [
+      -73.96785533,
+      40.80298423
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "600 MADISON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134168",
+    "coordinates": [
+      -73.9720295,
+      40.7629065
+    ]
+  },
+  {
+    "street_address": "2408 UNIVERSITY AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-111540",
+    "coordinates": [
+      -73.90457508,
+      40.86311405
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "201 EAST 64 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121750",
+    "coordinates": [
+      -73.96407554,
+      40.76465351
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1149 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-108039",
+    "coordinates": [
+      -73.98901592,
+      40.74424305
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "451 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133465",
+    "coordinates": [
+      -73.979316,
+      40.743876
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "35-19 31 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-146038",
+    "coordinates": [
+      -73.919579,
+      40.762564
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122299",
+    "coordinates": [
+      -74.002305,
+      40.739846
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "798 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121822",
+    "coordinates": [
+      -73.97125096,
+      40.75535623
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "842 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-133671",
+    "coordinates": [
+      -73.96807,
+      40.797391
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "599 WEST 190 STREET",
+    "type": "LINK1.0",
+    "id": "mn-12-131047",
+    "coordinates": [
+      -73.9293896,
+      40.85487571
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "895 WALTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-04-101603",
+    "coordinates": [
+      -73.92390599,
+      40.82765532
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "677 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120599",
+    "coordinates": [
+      -73.96891544,
+      40.79078578
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2205 HYLAN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "si-02-145731",
+    "coordinates": [
+      -74.10356538,
+      40.57681082
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "74-04 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-136360",
+    "coordinates": [
+      -73.89121486,
+      40.74679775
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1293 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-122369",
+    "coordinates": [
+      -73.98808378,
+      40.74972091
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "743 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121416",
+    "coordinates": [
+      -73.973319,
+      40.748513
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "192 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138575",
+    "coordinates": [
+      -73.985739,
+      40.73108
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3497 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120360",
+    "coordinates": [
+      -73.9516557,
+      40.8250896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "628 HUDSON STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-108535",
+    "coordinates": [
+      -74.00546559,
+      40.73835105
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "180 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133531",
+    "coordinates": [
+      -73.98625935,
+      40.73476963
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-12 150 STREET",
+    "type": "LINK1.0",
+    "id": "qu-12-150179",
+    "coordinates": [
+      -73.8033556,
+      40.6996142
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "121 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-123517",
+    "coordinates": [
+      -74.00372466,
+      40.74341383
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "176 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135037",
+    "coordinates": [
+      -74.000238,
+      40.742689
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "817 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-108104",
+    "coordinates": [
+      -73.968542,
+      40.796374
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163 EAST 42 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121368",
+    "coordinates": [
+      -73.97518778,
+      40.75118164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "163-08 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-12-138095",
+    "coordinates": [
+      -73.79662039,
+      40.70468655
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1410 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-107971",
+    "coordinates": [
+      -73.95460936,
+      40.76950566
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-17 MERRICK BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-159306",
+    "coordinates": [
+      -73.7880885,
+      40.6997274
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1421 5 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120070",
+    "coordinates": [
+      -73.94624056,
+      40.8007812
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "470 VANDERBILT AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-02-145868",
+    "coordinates": [
+      -73.96775318,
+      40.68226753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "133 EAST 58 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-121900",
+    "coordinates": [
+      -73.96880182,
+      40.76173086
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "455 DUMONT AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-150013",
+    "coordinates": [
+      -73.902027,
+      40.6652259
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "126 EAST 41 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-133550",
+    "coordinates": [
+      -73.97681673,
+      40.75083273
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40-17 30 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-125114",
+    "coordinates": [
+      -73.914259,
+      40.763621
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "159 WEST 52 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-137157",
+    "coordinates": [
+      -73.98188075,
+      40.7622099
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2 EAST 172 STREET",
+    "type": "LINK1.0",
+    "id": "bx-04-146072",
+    "coordinates": [
+      -73.91603242,
+      40.84220263
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "241 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134843",
+    "coordinates": [
+      -73.98254791,
+      40.73160198
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "96-70 QUEENS BOULEVARD",
+    "type": "LINK5G_Ad",
+    "id": "qu-06-144552",
+    "coordinates": [
+      -73.8605662,
+      40.7292088
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1251 REV JAMES POLITE AVE",
+    "type": "LINK1.0",
+    "id": "bx-02-158315",
+    "coordinates": [
+      -73.8965543,
+      40.8286736
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "165 EAST BROADWAY",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-134173",
+    "coordinates": [
+      -73.9899828,
+      40.7139997
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "270 WEST 47 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122591",
+    "coordinates": [
+      -73.987313,
+      40.760283
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "656 10 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135797",
+    "coordinates": [
+      -73.99336769,
+      40.76233629
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "117 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-136743",
+    "coordinates": [
+      -74.00400454,
+      40.74302673
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "454 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-121275",
+    "coordinates": [
+      -73.9742489,
+      40.78382538
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "543 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121511",
+    "coordinates": [
+      -73.977005,
+      40.74705
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1530 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-119826",
+    "coordinates": [
+      -73.95398,
+      40.779038
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1848 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-118932",
+    "coordinates": [
+      -73.90139163,
+      40.84664641
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45-02 VAN DAM STREET",
+    "type": "LINK1.0",
+    "id": "qu-02-145780",
+    "coordinates": [
+      -73.933726,
+      40.744608
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "106-15 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145880",
+    "coordinates": [
+      -73.84055056,
+      40.69541981
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "613 WESTCHESTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-142736",
+    "coordinates": [
+      -73.90991661,
+      40.81618821
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "203 EAST 39 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-138030",
+    "coordinates": [
+      -73.97536339,
+      40.7487328
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "63-14 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-02-145778",
+    "coordinates": [
+      -73.901886,
+      40.740962
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2160 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-07-133404",
+    "coordinates": [
+      -73.98083572,
+      40.78185329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "121 WEST 67 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-133488",
+    "coordinates": [
+      -73.982571,
+      40.774894
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "145 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-108269",
+    "coordinates": [
+      -73.985083,
+      40.728126
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 106 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-107743",
+    "coordinates": [
+      -73.96610661,
+      40.80050433
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2454 CRESTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119569",
+    "coordinates": [
+      -73.89839588,
+      40.86215226
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "499 WEST 135 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-146052",
+    "coordinates": [
+      -73.95187039,
+      40.81886798
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1100 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122814",
+    "coordinates": [
+      -73.98389868,
+      40.75495098
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1450 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-121010",
+    "coordinates": [
+      -73.95593074,
+      40.77636605
+    ]
+  },
+  {
+    "street_address": "2407 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-111709",
+    "coordinates": [
+      -73.94948944,
+      40.81265566
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "223 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123282",
+    "coordinates": [
+      -73.9851321,
+      40.73224694
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "176 EAST 77 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120997",
+    "coordinates": [
+      -73.958474,
+      40.773003
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2346 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-137181",
+    "coordinates": [
+      -73.950658,
+      40.81069
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1077 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121773",
+    "coordinates": [
+      -73.96550379,
+      40.75923366
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "60 LAFAYETTE STREET",
+    "type": "LINK1.0",
+    "id": "mn-01-138237",
+    "coordinates": [
+      -74.002253,
+      40.716682
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "108-25 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-145879",
+    "coordinates": [
+      -73.83880988,
+      40.69591252
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94 HESTER STREET",
+    "type": "LINK5G_Ad",
+    "id": "mn-03-158275",
+    "coordinates": [
+      -73.9926704,
+      40.7163875
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2817 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-119900",
+    "coordinates": [
+      -73.93976734,
+      40.82596687
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 EAST 73 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-120842",
+    "coordinates": [
+      -73.95536175,
+      40.76837393
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1 EAST 177 STREET",
+    "type": "LINK1.0",
+    "id": "bx-05-146097",
+    "coordinates": [
+      -73.91028173,
+      40.850173
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "777 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-134736",
+    "coordinates": [
+      -73.98309028,
+      40.76114197
+    ],
+    "status": "pending"
+  },
+  {
+    "street_address": "560 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121522",
+    "coordinates": [
+      -73.97677658,
+      40.74778786
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1881 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-131062",
+    "coordinates": [
+      -73.94375597,
+      40.83033563
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "98-04 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-124200",
+    "coordinates": [
+      -73.858076,
+      40.728299
+    ]
+  },
+  {
+    "street_address": "89 9 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-135171",
+    "coordinates": [
+      -74.00444413,
+      40.74241855
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "59 WEST 28 STREET",
+    "type": "LINK1.0",
+    "id": "mn-05-122211",
+    "coordinates": [
+      -73.99028957,
+      40.74600486
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "87 MELROSE STREET",
+    "type": "LINK1.0",
+    "id": "bk-04-154814",
+    "coordinates": [
+      -73.934201,
+      40.6990728
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 NORTH 9 STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-146017",
+    "coordinates": [
+      -73.96035235,
+      40.72138255
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "15 DEBEVOISE STREET",
+    "type": "LINK1.0",
+    "id": "bk-01-138951",
+    "coordinates": [
+      -73.94248859,
+      40.70166753
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-02 71 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-06-124227",
+    "coordinates": [
+      -73.8446443,
+      40.72024516
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "343 COURT STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-126394",
+    "coordinates": [
+      -73.99575348,
+      40.68248292
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "615 4 AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-07-145887",
+    "coordinates": [
+      -73.993715,
+      40.664406
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "936 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-122633",
+    "coordinates": [
+      -73.9793497,
+      40.76664932
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "4351 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-134041",
+    "coordinates": [
+      -73.9343805,
+      40.8530796
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "171 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-02-126505",
+    "coordinates": [
+      -73.977006,
+      40.683625
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2070 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-142858",
+    "coordinates": [
+      -73.957067,
+      40.801938
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "359 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121499",
+    "coordinates": [
+      -73.981576,
+      40.740775
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "106 HENRY STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-125682",
+    "coordinates": [
+      -73.99302857,
+      40.69758777
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "95-36 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-111122",
+    "coordinates": [
+      -73.8704887,
+      40.74897101
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "400 EAST 68 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-135080",
+    "coordinates": [
+      -73.95769383,
+      40.76511946
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "943 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121676",
+    "coordinates": [
+      -73.96543425,
+      40.7550807
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "667 WARREN STREET",
+    "type": "LINK1.0",
+    "id": "bk-06-145896",
+    "coordinates": [
+      -73.978034,
+      40.680323
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "124 WEST 67 STREET",
+    "type": "LINK1.0",
+    "id": "mn-07-134275",
+    "coordinates": [
+      -73.98251236,
+      40.77475903
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1861 PITKIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-16-127124",
+    "coordinates": [
+      -73.90406,
+      40.670741
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-10 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-04-145745",
+    "coordinates": [
+      -73.877364,
+      40.736273
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "200 WEST 23 STREET",
+    "type": "LINK1.0",
+    "id": "mn-04-123494",
+    "coordinates": [
+      -73.995892,
+      40.744114
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "86-10 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-125330",
+    "coordinates": [
+      -73.88002682,
+      40.74798095
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2201 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-119615",
+    "coordinates": [
+      -73.9047427,
+      40.857222
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "18 UNION SQUARE EAST",
+    "type": "LINK1.0",
+    "id": "mn-05-123158",
+    "coordinates": [
+      -73.989871,
+      40.735187
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1626 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-134416",
+    "coordinates": [
+      -73.94964029,
+      40.82263345
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "40 EAST 83 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121051",
+    "coordinates": [
+      -73.96011567,
+      40.77879465
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2004 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-120232",
+    "coordinates": [
+      -73.94285894,
+      40.79427312
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1026 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-136985",
+    "coordinates": [
+      -73.96652752,
+      40.75741739
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2495 JEROME AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-07-145840",
+    "coordinates": [
+      -73.90051187,
+      40.86366546
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "809 SOUTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "bx-02-113121",
+    "coordinates": [
+      -73.8957114,
+      40.8169525
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "182 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123791",
+    "coordinates": [
+      -73.98382369,
+      40.72943593
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "464 GRAND AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-02-145793",
+    "coordinates": [
+      -73.9616482,
+      40.68219957
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1591 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-145760",
+    "coordinates": [
+      -73.937627,
+      40.67981536
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "995 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-136685",
+    "coordinates": [
+      -73.96144841,
+      40.80100105
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "386 UTICA AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bk-09-156895",
+    "coordinates": [
+      -73.9315921,
+      40.6651139
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "792 FRANKLIN AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-145993",
+    "coordinates": [
+      -73.957793,
+      40.671355
+    ]
+  },
+  {
+    "street_address": "2022 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-11-107915",
+    "coordinates": [
+      -73.94239654,
+      40.79491138
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "660 WESTCHESTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-123210",
+    "coordinates": [
+      -73.90824221,
+      40.81599771
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "326 EAST 194 STREET",
+    "type": "LINK1.0",
+    "id": "bx-07-119731",
+    "coordinates": [
+      -73.8914407,
+      40.8640937
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "550 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121991",
+    "coordinates": [
+      -73.98833004,
+      40.75431145
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "782 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-135581",
+    "coordinates": [
+      -73.96941887,
+      40.79554394
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "140 EAST 144 STREET",
+    "type": "LINK1.0",
+    "id": "bx-01-145820",
+    "coordinates": [
+      -73.92924285,
+      40.81675164
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "513 IRVING AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-04-126704",
+    "coordinates": [
+      -73.9062844,
+      40.6944743
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3800 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-12-111735",
+    "coordinates": [
+      -73.944176,
+      40.834722
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1961 ARTHUR AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-06-144410",
+    "coordinates": [
+      -73.89339767,
+      40.84652245
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "92-24 QUEENS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-06-156982",
+    "coordinates": [
+      -73.8681978,
+      40.7323913
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1126 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-08-120980",
+    "coordinates": [
+      -73.96358324,
+      40.76587983
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "890 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-139461",
+    "coordinates": [
+      -73.98454459,
+      40.76421225
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "107-23 JAMAICA AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-09-124794",
+    "coordinates": [
+      -73.83960659,
+      40.6956028
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "520 BROOK AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-146056",
+    "coordinates": [
+      -73.91518065,
+      40.81439418
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "248 DUFFIELD STREET",
+    "type": "LINK1.0",
+    "id": "bk-02-134976",
+    "coordinates": [
+      -73.984481,
+      40.690588
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "750 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-138006",
+    "coordinates": [
+      -73.99208429,
+      40.7437055
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "149-06 NORTHERN BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-07-124348",
+    "coordinates": [
+      -73.8171292,
+      40.7651077
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "966 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121688",
+    "coordinates": [
+      -73.96459519,
+      40.75581174
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "660 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-136857",
+    "coordinates": [
+      -73.97007156,
+      40.75980064
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "34-02 BROADWAY",
+    "type": "LINK1.0",
+    "id": "qu-01-125088",
+    "coordinates": [
+      -73.922879,
+      40.760713
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1422 ST. NICHOLAS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-12-120650",
+    "coordinates": [
+      -73.93352882,
+      40.84942275
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "825 WEST END AVENUE",
+    "type": "Public Payphones",
+    "id": "mn-07-120507",
+    "coordinates": [
+      -73.97137922,
+      40.79794552
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "45 HYATT STREET",
+    "type": "LINK5G_Ad",
+    "id": "si-01-154577",
+    "coordinates": [
+      -74.0776909,
+      40.6417686
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "460 WILLIS AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-01-116238",
+    "coordinates": [
+      -73.91917137,
+      40.81399752
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1290 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-118158",
+    "coordinates": [
+      -73.957517,
+      40.811845
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "183 7 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-115165",
+    "coordinates": [
+      -73.996549,
+      40.74267426
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2353 FREDERICK DOUGLASS BOULEVARD",
+    "type": "LINK1.0",
+    "id": "mn-10-120002",
+    "coordinates": [
+      -73.95071065,
+      40.81098881
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "41 HORATIO STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123497",
+    "coordinates": [
+      -74.00528546,
+      40.73879783
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "204-02 HILLSIDE AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "qu-12-128571",
+    "coordinates": [
+      -73.7609725,
+      40.7202061
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "80-05 ROOSEVELT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-03-100928",
+    "coordinates": [
+      -73.88549761,
+      40.74753882
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "185-07 MERRICK BOULEVARD",
+    "type": "LINK1.0",
+    "id": "qu-12-157796",
+    "coordinates": [
+      -73.7570369,
+      40.6797471
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "773 WASHINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-08-132895",
+    "coordinates": [
+      -73.96286903,
+      40.673692
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1238 AMSTERDAM AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-09-120545",
+    "coordinates": [
+      -73.958889,
+      40.809965
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "164 EAST 53 STREET",
+    "type": "LINK1.0",
+    "id": "mn-06-121839",
+    "coordinates": [
+      -73.96961496,
+      40.75772905
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "222 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-05-121484",
+    "coordinates": [
+      -73.9802333,
+      40.74586329
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "268 GREENE STREET",
+    "type": "LINK1.0",
+    "id": "mn-02-123843",
+    "coordinates": [
+      -73.99407922,
+      40.73116016
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "24 EAST 63 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121861",
+    "coordinates": [
+      -73.9699764,
+      40.7661935
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "180 1 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-138884",
+    "coordinates": [
+      -73.98397945,
+      40.72921987
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "35-12 35 AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-01-145921",
+    "coordinates": [
+      -73.92521461,
+      40.75652086
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "94-03 63 DRIVE",
+    "type": "LINK5G_Ad",
+    "id": "qu-06-107629",
+    "coordinates": [
+      -73.8632429,
+      40.7288322
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "279 11 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-140359",
+    "coordinates": [
+      -74.00491217,
+      40.75196913
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "731 8 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-122579",
+    "coordinates": [
+      -73.98811386,
+      40.75974624
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "95 WEST FORDHAM ROAD",
+    "type": "LINK1.0",
+    "id": "bx-07-119787",
+    "coordinates": [
+      -73.90454701,
+      40.86285548
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81 LEXINGTON AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-134680",
+    "coordinates": [
+      -73.983198,
+      40.741481
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "197 COLUMBUS AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-07-120926",
+    "coordinates": [
+      -73.98016085,
+      40.77535675
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "501 WEST 145 STREET",
+    "type": "LINK1.0",
+    "id": "mn-09-100210",
+    "coordinates": [
+      -73.947868,
+      40.825446
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "51-05 SKILLMAN AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-02-137493",
+    "coordinates": [
+      -73.9130555,
+      40.7460577
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1570 RICHMOND ROAD",
+    "type": "LINK1.0",
+    "id": "si-02-145829",
+    "coordinates": [
+      -74.10086158,
+      40.59143558
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "751 BERGEN STREET",
+    "type": "LINK1.0",
+    "id": "bk-08-145920",
+    "coordinates": [
+      -73.96373,
+      40.67854
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "265 NEW DORP LANE",
+    "type": "LINK1.0",
+    "id": "si-02-145727",
+    "coordinates": [
+      -74.113383,
+      40.57262
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "160 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-03-123268",
+    "coordinates": [
+      -73.98665837,
+      40.72983073
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "3601 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-09-120352",
+    "coordinates": [
+      -73.94913226,
+      40.82854185
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "2565 GRAND CONCOURSE",
+    "type": "LINK1.0",
+    "id": "bx-07-131009",
+    "coordinates": [
+      -73.8961845,
+      40.8643262
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1831 WEBSTER AVENUE",
+    "type": "LINK1.0",
+    "id": "bx-05-138759",
+    "coordinates": [
+      -73.901951,
+      40.846169
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "522 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-133709",
+    "coordinates": [
+      -73.97797283,
+      40.74171074
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1102 LONGFELLOW AVENUE",
+    "type": "LINK5G_Ad",
+    "id": "bx-02-100042",
+    "coordinates": [
+      -73.8877631,
+      40.8266802
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "711 6 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-04-134100",
+    "coordinates": [
+      -73.99300348,
+      40.74282792
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "597 FLATBUSH AVENUE",
+    "type": "LINK1.0",
+    "id": "bk-09-126559",
+    "coordinates": [
+      -73.960426,
+      40.658911
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "81-02 PETTIT AVENUE",
+    "type": "LINK1.0",
+    "id": "qu-04-145899",
+    "coordinates": [
+      -73.88378879,
+      40.74356322
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1626 BROADWAY",
+    "type": "LINK1.0",
+    "id": "mn-05-133508",
+    "coordinates": [
+      -73.98427739,
+      40.76088277
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "1874 FULTON STREET",
+    "type": "LINK1.0",
+    "id": "bk-03-126646",
+    "coordinates": [
+      -73.924424,
+      40.67896
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "950 3 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121733",
+    "coordinates": [
+      -73.9677744,
+      40.76013485
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "25 EAST 61 STREET",
+    "type": "LINK1.0",
+    "id": "mn-08-121980",
+    "coordinates": [
+      -73.970303,
+      40.764821
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "37-69 78 STREET",
+    "type": "LINK1.0",
+    "id": "qu-03-139602",
+    "coordinates": [
+      -73.88761509,
+      40.74741228
+    ],
+    "status": "active"
+  },
+  {
+    "street_address": "435 2 AVENUE",
+    "type": "LINK1.0",
+    "id": "mn-06-121446",
+    "coordinates": [
+      -73.98014812,
+      40.73913724
     ],
     "status": "active"
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,9 +5,13 @@ import linkData from "../data/links";
 import sectorData from "../data/sectors";
 import kiosks from "../data/kiosks";
 
+const kiosks5g = kiosks.filter(kiosk => kiosk.type.toLowerCase().includes("5g"));
+const kiosksClassic = kiosks.filter(kiosk => !kiosk.type.toLowerCase().includes("5g"));
+
 const initialFilters = {
 	remote: true,
-	linkNYC: false,
+	"linkNYC Classic": false,
+	"linkNYC 5G": false,
 	potential: false,
 	dead: false,
 	"potential-hub": true,
@@ -28,10 +32,11 @@ const reducer = (
 		nodes,
 		links,
 		sectors,
-		kiosks: initialFilters.linkNYC === false ? [] : kiosks,
+		kiosksClassic: initialFilters["linkNYC Classic"] === false ? [] : kiosksClassic,
+		kiosks5g: initialFilters["linkNYC 5G"] === false ? [] : kiosks5g,
 		nodesById,
 		filters: initialFilters,
-		statusCounts: getCounts(nodes, kiosks),
+		statusCounts: getCounts(nodes, kiosksClassic, kiosks5g),
 		showFilters: false
 	},
 	action
@@ -53,7 +58,9 @@ const reducer = (
 			return {
 				...state,
 				filters: newFilters,
-				kiosks: newFilters.linkNYC === false ? [] : kiosks
+				kiosksClassic: newFilters["linkNYC Classic"] === false ? [] : kiosksClassic,
+				kiosks5g: newFilters["linkNYC 5G"] === false ? [] : kiosks5g,
+				
 			};
 		case "TOGGLE_FILTERS":
 			return {
@@ -144,7 +151,7 @@ function addGraphData(nodes, links, sectors) {
 	return { nodes, links, sectors, nodesById };
 }
 
-function getCounts(nodes, kiosks) {
+function getCounts(nodes, kiosksClassic, kiosks5g) {
 	const counts = {};
 	nodes.forEach(node => {
 		const { type } = node;
@@ -154,7 +161,8 @@ function getCounts(nodes, kiosks) {
 			counts["sector"] = (counts["sector"] || 0) + node.sectors.length;
 		}
 	});
-	counts.linkNYC = kiosks.length;
+	counts["linkNYC Classic"] = kiosksClassic.length;
+	counts["linkNYC 5G"] = kiosks5g.length;
 	return counts;
 }
 


### PR DESCRIPTION
Splits LinkNYC kiosks layer into "Classic" and "5G".  Adds popup box to display kiosk data.

![image](https://github.com/nycmeshnet/network-map/assets/711780/3d7392ac-7d16-4ce9-a265-5539c6f6f44f)
