### PR TITLE
Add a few events to make integrations easier

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -17,7 +17,9 @@ class Map extends Component {
     constructor(props) {
         super(props);
         window.addEventListener("message", ({ data, source }) => {
-            this.updateSelected.bind(this)(data.selectedNodes, false);
+            if ('selectedNodes' in data) {
+                this.updateSelected.bind(this)(data.selectedNodes, false);
+            }
         });
     }
 
@@ -29,7 +31,7 @@ class Map extends Component {
         }
         if (triggerEvent) {
             console.log(`[map] Posting update: ${selectedNodes}`);
-            window.parent.postMessage({selectedNodes: selectedNodes}, MESHDB_URL);
+            window.parent.postMessage({selectedNodes: selectedNodes}, "*");
         }
     }
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -5,6 +5,7 @@ export function fetchNodes(dispatch) {
 		.then(res => res.json())
 		.then(json => {
 			console.log("Fetched Nodes");
+			window.parent.postMessage({type: "FETCH_NODES_SUCCESS"}, "*");
 			dispatch({ type: "FETCH_NODES_SUCCESS", nodes: json });
 		})
 		.catch(err => console.log(err));
@@ -15,6 +16,7 @@ export function fetchLinks(dispatch) {
 		.then(res => res.json())
 		.then(json => {
 			dispatch({ type: "FETCH_LINKS_SUCCESS", links: json });
+			window.parent.postMessage({type: "FETCH_LINKS_SUCCESS"}, "*");
 		})
 		.catch(err => console.log(err));
 }
@@ -24,6 +26,7 @@ export function fetchSectors(dispatch) {
 		.then(res => res.json())
 		.then(json => {
 			dispatch({ type: "FETCH_SECTORS_SUCCESS", sectors: json });
+			window.parent.postMessage({type: "FETCH_SECTORS_SUCCESS"}, "*");
 		})
 		.catch(err => console.log(err));
 }
@@ -33,6 +36,7 @@ export function fetchKiosks(dispatch) {
 		.then(res => res.json())
 		.then(json => {
 			dispatch({ type: "FETCH_KIOSKS_SUCCESS", kiosks: json });
+			window.parent.postMessage({type: "FETCH_KIOSKS_SUCCESS"}, "*");
 		})
 		.catch(err => console.log(err));
 }


### PR DESCRIPTION
I'm working on another project and want a small map embed for a part of it. I think I can use the meshdb admin map with only a few small modifications, noted here.

This change adds a few events for loading data, filters input events to only those that actually should update the map data (I was seeing an issue where react debug events were clearing the map, and this little filter fixed it)

Also uses `*` to allow all embedding sites to receive the messages. I don't think this is that big of a deal, the map data is all public and non-sensitive